### PR TITLE
Fix #6 collections of non primitive types not supported

### DIFF
--- a/core/src/main/scala/pickling/Custom.scala
+++ b/core/src/main/scala/pickling/Custom.scala
@@ -19,6 +19,7 @@ trait LowPriorityPicklersUnpicklers {
 
     val format: PickleFormat = pf
     val elemTag  = implicitly[FastTypeTag[T]]
+    val isPrimitive = elemTag.tpe.isEffectivelyPrimitive
 
     def pickle(coll: Coll[T], builder: PBuilder): Unit = {
       builder.hintTag(collTag)
@@ -27,38 +28,49 @@ trait LowPriorityPicklersUnpicklers {
       if (coll.isInstanceOf[IndexedSeq[_]]) builder.beginCollection(coll.size)
       else builder.beginCollection(0)
 
-      builder.hintStaticallyElidedType()
-      builder.hintTag(elemTag)
-      builder.pinHints()
+      if (isPrimitive) {
+        builder.hintStaticallyElidedType()
+        builder.hintTag(elemTag)
+        builder.pinHints()
+      }
 
       var i = 0
       coll.asInstanceOf[Traversable[T]].foreach { (elem: T) =>
-        builder.beginEntry(elem)
-        builder.endEntry()
+        builder putElement { b =>
+          if (!isPrimitive) b.hintTag(elemTag)
+          elemPickler.pickle(elem, b)
+        }
         i += 1
       }
 
-      builder.unpinHints()
+      if (isPrimitive) builder.unpinHints()
       builder.endCollection(i)
       builder.endEntry()
     }
 
     def unpickle(tpe: => FastTypeTag[_], preader: PReader): Any = {
       val reader = preader.beginCollection()
-      reader.hintStaticallyElidedType()
-      reader.hintTag(elemTag)
-      reader.pinHints()
+
+      if (isPrimitive) {
+        reader.hintStaticallyElidedType()
+        reader.hintTag(elemTag)
+        reader.pinHints()
+      }
 
       val length = reader.readLength()
-      var builder = cbf.apply() // builder with element type T
+      val builder = cbf.apply() // builder with element type T
       var i = 0
       while (i < length) {
-        reader.beginEntry()
-        builder += reader.readPrimitive().asInstanceOf[T]
-        reader.endEntry()
+        val r = reader.readElement()
+        r.beginEntryNoTag()
+        val elem = elemUnpickler.unpickle(elemTag, r)
+        r.endEntry()
+        builder += elem.asInstanceOf[T]
         i = i + 1
       }
 
+      if (isPrimitive) reader.unpinHints()
+      preader.endCollection()
       builder.result
     }
   }
@@ -88,7 +100,8 @@ trait CorePicklersUnpicklers extends GenPicklers with GenUnpicklers with LowPrio
   implicit val doublePicklerUnpickler: SPickler[Double] with Unpickler[Double] = new PrimitivePicklerUnpickler[Double]
   implicit val nullPicklerUnpickler: SPickler[Null] with Unpickler[Null] = new PrimitivePicklerUnpickler[Null]
 
-  implicit def genListPickler[T](implicit format: PickleFormat): SPickler[::[T]] with Unpickler[::[T]] = macro Compat.ListPicklerUnpicklerMacro_impl[T]
+  implicit def genListPickler[T](implicit format: PickleFormat): SPickler[::[T]] with Unpickler[::[T]] =
+    macro Compat.ListPicklerUnpicklerMacro_impl[T]
   // TODO: figure out why this is slower than traversablePickler
   // implicit def genVectorPickler[T](implicit format: PickleFormat): Pickler[Vector[T]] with Unpickler[Vector[T]] = macro VectorPicklerUnpicklerMacro.impl[T]
 }
@@ -130,7 +143,9 @@ trait CollectionPicklerUnpicklerMacro extends Macro {
         import scala.reflect.runtime.universe._
         import scala.pickling._
         import scala.pickling.`package`.PickleOps
+
         val format = new ${format.tpe}()
+
         implicit val elpickler: SPickler[$eltpe] = {
           val elpickler = "bam!"
           implicitly[SPickler[$eltpe]]
@@ -143,47 +158,48 @@ trait CollectionPicklerUnpicklerMacro extends Macro {
           val eltag = "bam!"
           implicitly[scala.pickling.FastTypeTag[$eltpe]]
         }
+
         def pickle(picklee: $tpe, builder: PBuilder): Unit = {
-          if (!$isPrimitive) throw new PicklingException(s"implementation restriction: non-primitive collections aren't supported")
           builder.beginEntry()
-          // TODO: this needs to be adjusted to work with non-primitive types
-          // 1) elisions might need to be set on per-element basis
-          // 2) val elpicker needs to be turned into def elpickler(el: $$eltpe) which would do dispatch
-          // 3) hint pinning would need to work with potentially nested picklings of elements
-          // ============
-          builder.hintStaticallyElidedType()
-          builder.hintTag(eltag)
-          builder.pinHints()
-          // ============
+          if ($isPrimitive) {
+            builder.hintStaticallyElidedType()
+            builder.hintTag(eltag)
+            builder.pinHints()
+          }
           val arr = ${mkArray(q"picklee")}
           val length = arr.length
           builder.beginCollection(arr.length)
           var i = 0
           while (i < arr.length) {
-            builder.putElement(b => elpickler.pickle(arr(i), b))
+            builder putElement { b =>
+              if (!$isPrimitive) b.hintTag(eltag)
+              elpickler.pickle(arr(i), b)
+            }
             i += 1
           }
-          builder.unpinHints()
+          if ($isPrimitive) builder.unpinHints()
           builder.endCollection(i)
           builder.endEntry()
         }
         def unpickle(tag: => scala.pickling.FastTypeTag[_], reader: PReader): Any = {
-          if (!$isPrimitive) throw new PicklingException(s"implementation restriction: non-primitive collections aren't supported")
           var buffer = ${mkBuffer(eltpe)}
           val arrReader = reader.beginCollection()
-          // TODO: this needs to be adjusted to work with non-primitive types
-          arrReader.hintStaticallyElidedType()
-          arrReader.hintTag(eltag)
-          arrReader.pinHints()
+          if ($isPrimitive) {
+            arrReader.hintStaticallyElidedType()
+            arrReader.hintTag(eltag)
+            arrReader.pinHints()
+          }
           val length = arrReader.readLength()
           var i = 0
           while (i < length) {
-            arrReader.beginEntry()
-            buffer += arrReader.readPrimitive().asInstanceOf[$eltpe]
-            arrReader.endEntry()
+            val r = arrReader.readElement()
+            r.beginEntryNoTag()
+            val elem = elunpickler.unpickle(eltag, r)
+            r.endEntry()
+            buffer += elem.asInstanceOf[$eltpe]
             i += 1
           }
-          arrReader.unpinHints()
+          if ($isPrimitive) arrReader.unpinHints()
           arrReader.endCollection()
           ${mkResult(q"buffer")}
         }

--- a/core/src/test/scala/pickling/binary-list-object.scala
+++ b/core/src/test/scala/pickling/binary-list-object.scala
@@ -1,0 +1,16 @@
+package scala.pickling.binary.list.obj
+
+import org.scalatest.FunSuite
+
+import scala.pickling._
+import binary._
+
+case class Person(name: String)
+
+class BinaryListObjectTest extends FunSuite {
+  test("main") {
+    val lst = List(Person("A"), Person("B"), Person("C"))
+    val pickle = lst.pickle
+    assert(pickle.unpickle[List[Person]] == List(Person("A"), Person("B"), Person("C")))
+  }
+}

--- a/core/src/test/scala/pickling/binary-vector-person.scala
+++ b/core/src/test/scala/pickling/binary-vector-person.scala
@@ -1,0 +1,14 @@
+package scala.pickling.binary.vector.person
+
+import org.scalatest.FunSuite
+import scala.pickling._
+import binary._
+
+case class Person(name: String)
+
+class BinaryVectorPerson extends FunSuite {
+  test("main") {
+    val pickle = Vector(Person("A"), Person("B"), Person("C")).pickle
+    assert(pickle.unpickle[Vector[Person]] === Vector(Person("A"), Person("B"), Person("C")))
+  }
+}


### PR DESCRIPTION
- traversablePickler supports collections of non-primitive elements
- genListPickler supports lists of non-primitive elements
