### PR TITLE
Improved PickleFormat customizability

### DIFF
--- a/core/src/main/scala/pickling/binary/BinaryPickleFormat.scala
+++ b/core/src/main/scala/pickling/binary/BinaryPickleFormat.scala
@@ -30,7 +30,7 @@ package binary {
         byteBuffer = if (knownSize != -1) new ByteArray(knownSize) else new ByteArrayBuffer
       }
 
-    def beginEntry(picklee: Any): this.type = withHints { hints =>
+    def beginEntry(picklee: Any): PBuilder = withHints { hints =>
       mkByteBuffer(hints.knownSize)
 
       if (picklee == null) {
@@ -81,7 +81,7 @@ package binary {
       this
     }
 
-    def putField(name: String, pickler: this.type => Unit): this.type = {
+    def putField(name: String, pickler: PBuilder => Unit): PBuilder = {
       // can skip writing name if we pickle/unpickle in the same order
       pickler(this)
       this
@@ -91,14 +91,14 @@ package binary {
 
     var beginCollPos = 0
 
-    def beginCollection(length: Int): this.type = {
+    def beginCollection(length: Int): PBuilder = {
       beginCollPos = pos
       byteBuffer.encodeIntAtEnd(pos, 0)
       pos += 4
       this
     }
 
-    def putElement(pickler: this.type => Unit): this.type = {
+    def putElement(pickler: PBuilder => Unit): PBuilder = {
       pickler(this)
       this
     }

--- a/core/src/main/scala/pickling/json/JSONPickleFormat.scala
+++ b/core/src/main/scala/pickling/json/JSONPickleFormat.scala
@@ -84,7 +84,7 @@ package json {
       FastTypeTag.JavaString.key -> ((picklee: Any) => append("\"" + JSONFormat.quoteString(picklee.toString) + "\"")),
       FastTypeTag.ArrayInt.key -> ((picklee: Any) => pickleArray(picklee.asInstanceOf[Array[Int]], FastTypeTag.Int))
     )
-    def beginEntry(picklee: Any): this.type = withHints { hints =>
+    def beginEntry(picklee: Any): PBuilder = withHints { hints =>
       indent()
       tags.push(hints.tag)
       if (primitives.contains(hints.tag.key)) {
@@ -107,7 +107,7 @@ package json {
       }
       this
     }
-    def putField(name: String, pickler: this.type => Unit): this.type = {
+    def putField(name: String, pickler: PBuilder => Unit): PBuilder = {
       // assert(!primitives.contains(tags.top.key), tags.top)
       if (!lastIsBrace) appendLine(",") // TODO: very inefficient, but here we don't care much about performance
       append("\"" + name + "\": ")
@@ -119,13 +119,13 @@ package json {
       if (primitives.contains(tags.pop().key)) () // do nothing
       else { appendLine(); append("}") }
     }
-    def beginCollection(length: Int): this.type = {
+    def beginCollection(length: Int): PBuilder = {
       putField("elems", b => ())
       appendLine("[")
       // indent()
       this
     }
-    def putElement(pickler: this.type => Unit): this.type = {
+    def putElement(pickler: PBuilder => Unit): PBuilder = {
       if (!lastIsBracket) appendLine(",") // TODO: very inefficient, but here we don't care much about performance
       pickler(this)
       this

--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -171,7 +171,7 @@ package pickling {
 
   trait PickleFormat {
     type PickleType <: Pickle
-    type OutputType <: Output[_]
+    type OutputType
     def createBuilder(): PBuilder
     def createBuilder(out: OutputType): PBuilder
     def createReader(pickle: PickleType, mirror: Mirror): PReader
@@ -187,11 +187,11 @@ package pickling {
   }
 
   trait PBuilder extends Hintable {
-    def beginEntry(picklee: Any): this.type
-    def putField(name: String, pickler: this.type => Unit): this.type
+    def beginEntry(picklee: Any): PBuilder
+    def putField(name: String, pickler: PBuilder => Unit): PBuilder
     def endEntry(): Unit
-    def beginCollection(length: Int): this.type
-    def putElement(pickler: this.type => Unit): this.type
+    def beginCollection(length: Int): PBuilder
+    def putElement(pickler: PBuilder => Unit): PBuilder
     def endCollection(length: Int): Unit
     def result(): Pickle
   }


### PR DESCRIPTION
**Retargeted PR for issue #7.**

Two things here:

I have removed the `<: Output[_]` constraint on `scala.pickling.PickleFormat.OutputType` as it is unnecessary. In addition, the `Output[T]` trait seems to be unnecessary. At the very least it makes little to no sense for non-linear output formats.

I have alterered `PBuilder` to return `PBuilder` as opposed to `this.type` - experimentation suggests that this makes it very difficult to construct a recursive builder. I can't think why you would need `this.type`, as the `PBuilder` interface should be called by `scala.pickling` code anyways (it is an inward-facing interface). It is possible I am missing something wrt macro considerations, however this seems to match `PReader`.

Both commits compile and test.
