### PR TITLE
Replaced seq, set, map, and array picklers with generic traversable pickler (no macros)

### DIFF
--- a/core/src/main/scala/pickling/Compat.scala
+++ b/core/src/main/scala/pickling/Compat.scala
@@ -61,70 +61,10 @@ object Compat {
     c.Expr[T](bundle.readerUnpickleTopLevel[T])
   }
 
-  def ArrayPicklerUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[T] with Unpickler[T]] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with ArrayPicklerUnpicklerMacro
-    c.Expr[SPickler[T] with Unpickler[T]](bundle.impl[T](format.tree))
-  }
-
-  def SeqPicklerUnpicklerMacro_impl[T: c.WeakTypeTag, Coll[_] <: Seq[_]](c: Context)(format: c.Expr[PickleFormat], cbf: c.Expr[CanBuildFrom[Coll[T], T, Coll[T]]]): c.Expr[SPickler[Coll[T]] with Unpickler[Coll[T]]] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with SeqPicklerUnpicklerMacro
-    c.Expr[SPickler[Coll[T]] with Unpickler[Coll[T]]](bundle.impl[T, Coll](format.tree, cbf.tree))
-  }
-
-  def IterablePicklerUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[T] with Unpickler[T]] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with IterablePicklerUnpicklerMacro
-    c.Expr[SPickler[T] with Unpickler[T]](bundle.impl[T](format.tree))
-  }
-
   def ListPicklerUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[T] with Unpickler[T]] = {
     val c0: c.type = c
     val bundle = new { val c: c0.type = c0 } with ListPicklerUnpicklerMacro
     c.Expr[SPickler[T] with Unpickler[T]](bundle.impl[T](format.tree))
-  }
-
-  def ImmSetPicklerUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[T] with Unpickler[T]] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with ImmSetPicklerUnpicklerMacro
-    c.Expr[SPickler[T] with Unpickler[T]](bundle.impl[T](format.tree))
-  }
-
-  def ImmSortedSetPicklerUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[T] with Unpickler[T]] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with ImmSortedSetPicklerUnpicklerMacro
-    c.Expr[SPickler[T] with Unpickler[T]](bundle.impl[T](format.tree))
-  }
-
-  def MutSetPicklerUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[T] with Unpickler[T]] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with MutSetPicklerUnpicklerMacro
-    c.Expr[SPickler[T] with Unpickler[T]](bundle.impl[T](format.tree))
-  }
-
-  def MutSortedSetPicklerUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[T] with Unpickler[T]] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with MutSortedSetPicklerUnpicklerMacro
-    c.Expr[SPickler[T] with Unpickler[T]](bundle.impl[T](format.tree))
-  }
-
-  def ImmMapPicklerUnpicklerMacro_impl[K: c.WeakTypeTag, V: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[Map[K, V]] with Unpickler[Map[K, V]]] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with ImmMapPicklerUnpicklerMacro
-    c.Expr[SPickler[Map[K, V]] with Unpickler[Map[K, V]]](bundle.impl[K, V](format.tree))
-  }
-
-  def ImmSortedMapPicklerUnpicklerMacro_impl[K: c.WeakTypeTag, V: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[immutable.SortedMap[K, V]] with Unpickler[immutable.SortedMap[K, V]]] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with ImmSortedMapPicklerUnpicklerMacro
-    c.Expr[SPickler[immutable.SortedMap[K, V]] with Unpickler[immutable.SortedMap[K, V]]](bundle.impl[K, V](format.tree))
-  }
-
-  def MutMapPicklerUnpicklerMacro_impl[K: c.WeakTypeTag, V: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[mutable.Map[K, V]] with Unpickler[mutable.Map[K, V]]] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with MutMapPicklerUnpicklerMacro
-    c.Expr[SPickler[mutable.Map[K, V]] with Unpickler[mutable.Map[K, V]]](bundle.impl[K, V](format.tree))
   }
 
   def PicklerMacros_dpicklerImpl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[DPickler[T]] = {

--- a/core/src/main/scala/pickling/Custom.scala
+++ b/core/src/main/scala/pickling/Custom.scala
@@ -22,148 +22,138 @@ class PicklerUnpicklerNotFound[T] extends SPickler[T] with Unpickler[T] {
 
 trait LowPriorityPicklersUnpicklers {
 
-/*
-  implicit def seqPickler[T, Coll[_] <: Seq[_]]
-    (implicit /*elemPickler: SPickler[T], elemUnpickler: Unpickler[T],*/
-              format: PickleFormat, cbf: CanBuildFrom[Coll[T], T, Coll[T]]): SPickler[Coll[T]] with Unpickler[Coll[T]] =
-    macro Compat.SeqPicklerUnpicklerMacro_impl[T, Coll]
-*/
-
   // collections
-  implicit def seqPickler[T](implicit format: PickleFormat, cbf: CanBuildFrom[Seq[T], T, Seq[T]]): SPickler[Seq[T]] with Unpickler[Seq[T]] = macro Compat.SeqPicklerUnpicklerMacro_impl[T, Seq]
-  implicit def indexedSeqPickler[T](implicit format: PickleFormat, cbf: CanBuildFrom[IndexedSeq[T], T, IndexedSeq[T]]): SPickler[IndexedSeq[T]] with Unpickler[IndexedSeq[T]] = macro Compat.SeqPicklerUnpicklerMacro_impl[T, IndexedSeq]
-  implicit def linearSeqPickler[T](implicit format: PickleFormat, cbf: CanBuildFrom[LinearSeq[T], T, LinearSeq[T]]): SPickler[LinearSeq[T]] with Unpickler[LinearSeq[T]] = macro Compat.SeqPicklerUnpicklerMacro_impl[T, LinearSeq]
+
+  implicit def iterablePickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[Iterable[T]], format: PickleFormat, cbf: CanBuildFrom[Iterable[T], T, Iterable[T]]): SPickler[Iterable[T]] with Unpickler[Iterable[T]] =
+    mkTravPickler[T, Iterable[T]]
+
+  implicit def seqPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[Seq[T]], format: PickleFormat, cbf: CanBuildFrom[Seq[T], T, Seq[T]]): SPickler[Seq[T]] with Unpickler[Seq[T]] =
+    mkSeqSetPickler[T, Seq]
+
+  implicit def indexedSeqPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[IndexedSeq[T]], format: PickleFormat, cbf: CanBuildFrom[IndexedSeq[T], T, IndexedSeq[T]]): SPickler[IndexedSeq[T]] with Unpickler[IndexedSeq[T]] =
+    mkSeqSetPickler[T, IndexedSeq]
+
+  implicit def linearSeqPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[LinearSeq[T]], format: PickleFormat, cbf: CanBuildFrom[LinearSeq[T], T, LinearSeq[T]]): SPickler[LinearSeq[T]] with Unpickler[LinearSeq[T]] =
+    mkSeqSetPickler[T, LinearSeq]
 
   // immutable collections
-  implicit def vectorPickler[T](implicit format: PickleFormat, cbf: CanBuildFrom[Vector[T], T, Vector[T]]): SPickler[Vector[T]] with Unpickler[Vector[T]] = macro Compat.SeqPicklerUnpicklerMacro_impl[T, Vector]
+
+  implicit def vectorPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[Vector[T]], format: PickleFormat, cbf: CanBuildFrom[Vector[T], T, Vector[T]]): SPickler[Vector[T]] with Unpickler[Vector[T]] =
+    mkSeqSetPickler[T, Vector]
+
+  // TODO: use this instead of the genListPickler
+  // implicit def listPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[::[T]], format: PickleFormat, cbf: CanBuildFrom[::[T], T, ::[T]]): SPickler[::[T]] with Unpickler[::[T]] =
+  //   mkSeqSetPickler[T, ::]
 
   // mutable collections
-  implicit def arrayBufferPickler[T](implicit format: PickleFormat, cbf: CanBuildFrom[ArrayBuffer[T], T, ArrayBuffer[T]]): SPickler[ArrayBuffer[T]] with Unpickler[ArrayBuffer[T]] = macro Compat.SeqPicklerUnpicklerMacro_impl[T, ArrayBuffer]
 
-}
+  implicit def arrayPickler[T >: Null: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[Array[T]], format: PickleFormat, cbf: CanBuildFrom[Array[T], T, Array[T]]): SPickler[Array[T]] with Unpickler[Array[T]] =
+    mkTravPickler[T, Array[T]]
 
-trait SeqPicklerUnpicklerMacro extends Macro {
-  def impl[T: c.WeakTypeTag, Coll[_] <: Seq[_]](format: c.Tree, cbf: c.Tree): c.Tree = {
-    import c.universe._
-    import definitions._
+  implicit def arrayBufferPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[ArrayBuffer[T]], format: PickleFormat, cbf: CanBuildFrom[ArrayBuffer[T], T, ArrayBuffer[T]]): SPickler[ArrayBuffer[T]] with Unpickler[ArrayBuffer[T]] =
+    mkSeqSetPickler[T, ArrayBuffer]
 
-    c.macroApplication match {
-      case q"$method[..$targs](..$args)" =>
-        val eltpt     = targs(0)
-        val eltpe     = eltpt.tpe
-        val Some(tpe) = args(1).tpe.find(_ <:< weakTypeOf[Seq[T]])
+  // sets
 
-        //val colltpe = colltpt.tpe
-        //val tpe     = appliedType(colltpe, List(eltpe))
-        //println("tpe: " + tpe.toString)
+  implicit def immSetPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[Set[T]], format: PickleFormat, cbf: CanBuildFrom[Set[T], T, Set[T]]): SPickler[Set[T]] with Unpickler[Set[T]] =
+    mkSeqSetPickler[T, Set]
 
-        val isPrimitive = eltpe.isEffectivelyPrimitive
-        val isFinal     = eltpe.isEffectivelyFinal
+  implicit def immSortedSetPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[immutable.SortedSet[T]], format: PickleFormat, cbf: CanBuildFrom[immutable.SortedSet[T], T, immutable.SortedSet[T]]): SPickler[immutable.SortedSet[T]] with Unpickler[immutable.SortedSet[T]] =
+    mkSeqSetPickler[T, immutable.SortedSet]
 
-        val picklerUnpicklerName = c.fresh(syntheticPicklerUnpicklerName(tpe).toTermName)
+  implicit def mutSetPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[mutable.Set[T]], format: PickleFormat, cbf: CanBuildFrom[mutable.Set[T], T, mutable.Set[T]]): SPickler[mutable.Set[T]] with Unpickler[mutable.Set[T]] =
+    mkSeqSetPickler[T, mutable.Set]
 
-        q"""
-          implicit object $picklerUnpicklerName extends scala.pickling.SPickler[$tpe] with scala.pickling.Unpickler[$tpe] {
-            import scala.reflect.runtime.universe._
-            import scala.pickling._
-            import scala.pickling.`package`.PickleOps
+  implicit def mutSortedSetPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[mutable.SortedSet[T]], format: PickleFormat, cbf: CanBuildFrom[mutable.SortedSet[T], T, mutable.SortedSet[T]]): SPickler[mutable.SortedSet[T]] with Unpickler[mutable.SortedSet[T]] =
+    mkSeqSetPickler[T, mutable.SortedSet]
 
-            val format = implicitly[${format.tpe}]
+  // maps
 
-            val elpickler: SPickler[$eltpe] = {
-              val elpickler = "bam!"
-              implicitly[SPickler[$eltpe]]
-            }
-            val elunpickler: Unpickler[$eltpe] = {
-              val elunpickler = "bam!"
-              implicitly[Unpickler[$eltpe]]
-            }
-            val eltag: scala.pickling.FastTypeTag[$eltpe] = {
-              val eltag = "bam!"
-              implicitly[scala.pickling.FastTypeTag[$eltpe]]
-            }
-            val colltag: scala.pickling.FastTypeTag[$tpe] = {
-              val colltag = "bam!"
-              implicitly[scala.pickling.FastTypeTag[$tpe]]
-            }
+  implicit def immMapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: SPickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[Map[K, V]], format: PickleFormat, cbf: CanBuildFrom[Map[K, V], (K, V), Map[K, V]]): SPickler[Map[K, V]] with Unpickler[Map[K, V]] =
+    mkMapPickler[K, V, Map]
 
-            def pickle(picklee: $tpe, builder: PBuilder): Unit = {
-              builder.hintTag(colltag)
-              ${
-                if (eltpe =:= IntTpe) q"builder.hintKnownSize(picklee.length * 4 + 100)".asInstanceOf[Tree]
-                else q"".asInstanceOf[Tree]
-              }
-              builder.beginEntry(picklee)
-              ${
-                if (isPrimitive) q"builder.hintStaticallyElidedType(); builder.hintTag(eltag); builder.pinHints()".asInstanceOf[Tree]
-                else q"".asInstanceOf[Tree]
-              }
-              val length = picklee.length
-              builder.beginCollection(length)
-              var i = 0
-              while (i < length) {
-                builder putElement { b =>
-                  ${
-                    if (!isPrimitive && !isFinal) q"""
-                      b.hintTag(eltag)
-                      picklee(i).pickleInto(b)
-                    """.asInstanceOf[Tree] else if (!isPrimitive && isFinal) q"""
-                      b.hintTag(eltag)
-                      b.hintStaticallyElidedType()
-                      picklee(i).pickleInto(b)
-                    """.asInstanceOf[Tree] else q"""
-                      elpickler.pickle(picklee(i), b)
-                    """.asInstanceOf[Tree]
-                  }
-                }
-                i += 1
-              }
-              ${
-                if (isPrimitive) q"builder.unpinHints()".asInstanceOf[Tree]
-                else q"".asInstanceOf[Tree]
-              }
-              builder.endCollection(i)
-              builder.endEntry()
-            }
-            def unpickle(tag: => scala.pickling.FastTypeTag[_], reader: PReader): Any = {
-              val arrReader = reader.beginCollection()
-              ${
-                if (isPrimitive) q"arrReader.hintStaticallyElidedType(); arrReader.hintTag(eltag); arrReader.pinHints()".asInstanceOf[Tree]
-                else q"".asInstanceOf[Tree]
-              }
-              val length = arrReader.readLength()
-              var buffer = $cbf()
-              var i = 0
-              while (i < length) {
-                val r = arrReader.readElement()
-                ${
-                  if (isPrimitive) q"""
-                    r.beginEntryNoTag()
-                    val elem = elunpickler.unpickle(eltag, r).asInstanceOf[$eltpe]
-                    r.endEntry()
-                    buffer += elem
-                  """.asInstanceOf[Tree] else q"""
-                    val elem = r.unpickle[$eltpe]
-                    buffer += elem
-                  """.asInstanceOf[Tree]
-                }
-                i += 1
-              }
-              ${
-                if (isPrimitive) q"arrReader.unpinHints()".asInstanceOf[Tree]
-                else q"".asInstanceOf[Tree]
-              }
-              arrReader.endCollection()
-              buffer.result()
-            }
-          }
-          $picklerUnpicklerName
-        """
+  implicit def immSortedMapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: SPickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[immutable.SortedMap[K, V]], format: PickleFormat, cbf: CanBuildFrom[immutable.SortedMap[K, V], (K, V), immutable.SortedMap[K, V]]): SPickler[immutable.SortedMap[K, V]] with Unpickler[immutable.SortedMap[K, V]] =
+    mkMapPickler[K, V, immutable.SortedMap]
 
-      case _ =>
-        throw new PicklingException("internal error")
+  implicit def mutMapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: SPickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[mutable.Map[K, V]], format: PickleFormat, cbf: CanBuildFrom[mutable.Map[K, V], (K, V), mutable.Map[K, V]]): SPickler[mutable.Map[K, V]] with Unpickler[mutable.Map[K, V]] =
+    mkMapPickler[K, V, mutable.Map]
+
+  def mkTravPickler[T: FastTypeTag, C <% Traversable[_]: FastTypeTag]
+    (implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+              pf: PickleFormat, cbf: CanBuildFrom[C, T, C],
+              collTag: FastTypeTag[C]): SPickler[C] with Unpickler[C] =
+    new SPickler[C] with Unpickler[C] {
+
+    val format: PickleFormat = pf
+    val elemTag  = implicitly[FastTypeTag[T]]
+    val isPrimitive = elemTag.tpe.isEffectivelyPrimitive
+
+    def pickle(coll: C, builder: PBuilder): Unit = {
+      builder.hintTag(collTag)
+      if (elemTag == FastTypeTag.Int) builder.hintKnownSize(coll.size * 4 + 100)
+      builder.beginEntry(coll)
+
+      if (coll.isInstanceOf[IndexedSeq[_]]) builder.beginCollection(coll.size)
+      else builder.beginCollection(0)
+
+      if (isPrimitive) {
+        builder.hintStaticallyElidedType()
+        builder.hintTag(elemTag)
+        builder.pinHints()
+      }
+
+      var i = 0
+      (coll: Traversable[_]).asInstanceOf[Traversable[T]].foreach { (elem: T) =>
+        builder putElement { b =>
+          if (!isPrimitive) b.hintTag(elemTag)
+          elemPickler.pickle(elem, b)
+        }
+        i += 1
+      }
+
+      if (isPrimitive) builder.unpinHints()
+      builder.endCollection(i)
+      builder.endEntry()
+    }
+
+    def unpickle(tpe: => FastTypeTag[_], preader: PReader): Any = {
+      val reader = preader.beginCollection()
+
+      if (isPrimitive) {
+        reader.hintStaticallyElidedType()
+        reader.hintTag(elemTag)
+        reader.pinHints()
+      }
+
+      val length = reader.readLength()
+      val builder = cbf.apply() // builder with element type T
+      var i = 0
+      while (i < length) {
+        val r = reader.readElement()
+        r.beginEntryNoTag()
+        val elem = elemUnpickler.unpickle(elemTag, r)
+        r.endEntry()
+        builder += elem.asInstanceOf[T]
+        i = i + 1
+      }
+
+      if (isPrimitive) reader.unpinHints()
+      preader.endCollection()
+      builder.result
     }
   }
+
+  def mkMapPickler[K: FastTypeTag, V: FastTypeTag, M[_, _] <: collection.Map[_, _]]
+    (implicit elemPickler: SPickler[(K, V)], elemUnpickler: Unpickler[(K, V)],
+              pf: PickleFormat, cbf: CanBuildFrom[M[K, V], (K, V), M[K, V]],
+              pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[M[K, V]]): SPickler[M[K, V]] with Unpickler[M[K, V]] =
+    mkTravPickler[(K, V), M[K, V]]
+
+  def mkSeqSetPickler[T: FastTypeTag, Coll[_] <: Traversable[_]]
+    (implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+              pf: PickleFormat, cbf: CanBuildFrom[Coll[T], T, Coll[T]],
+              collTag: FastTypeTag[Coll[T]]): SPickler[Coll[T]] with Unpickler[Coll[T]] =
+    mkTravPickler[T, Coll[T]]
 }
 
 trait CollectionPicklerUnpicklerMacro extends Macro {
@@ -308,39 +298,8 @@ trait CorePicklersUnpicklers extends GenPicklers with GenUnpicklers with LowPrio
   implicit def refPickler: SPickler[refs.Ref] = throw new Error("cannot pickle refs") // TODO: make this a macro
   implicit val refUnpickler: Unpickler[refs.Ref] = new PrimitivePicklerUnpickler[refs.Ref]
 
-  implicit def genIterablePickler[T](implicit format: PickleFormat): SPickler[Iterable[T]] with Unpickler[Iterable[T]] = macro Compat.IterablePicklerUnpicklerMacro_impl[T]
-  implicit def genArrayPickler[T >: Null](implicit format: PickleFormat): SPickler[Array[T]] with Unpickler[Array[T]] = macro Compat.ArrayPicklerUnpicklerMacro_impl[T]
+  // TODO: remove this in favor of the implicit listPickler above
   implicit def genListPickler[T](implicit format: PickleFormat): SPickler[::[T]] with Unpickler[::[T]] = macro Compat.ListPicklerUnpicklerMacro_impl[T]
-
-  implicit def genImmSetPickler[T](implicit format: PickleFormat): SPickler[Set[T]] with Unpickler[Set[T]] = macro Compat.ImmSetPicklerUnpicklerMacro_impl[T]
-  implicit def genImmSortedSetPickler[T](implicit format: PickleFormat): SPickler[immutable.SortedSet[T]] with Unpickler[immutable.SortedSet[T]] = macro Compat.ImmSortedSetPicklerUnpicklerMacro_impl[T]
-  implicit def genMutSetPickler[T](implicit format: PickleFormat): SPickler[mutable.Set[T]] with Unpickler[mutable.Set[T]] = macro Compat.MutSetPicklerUnpicklerMacro_impl[T]
-  implicit def genMutSortedSetPickler[T](implicit format: PickleFormat): SPickler[mutable.SortedSet[T]] with Unpickler[mutable.SortedSet[T]] = macro Compat.MutSortedSetPicklerUnpicklerMacro_impl[T]
-
-  implicit def genImmMapPickler[K, V](implicit format: PickleFormat): SPickler[Map[K, V]] with Unpickler[Map[K, V]] = macro Compat.ImmMapPicklerUnpicklerMacro_impl[K, V]
-  implicit def genImmSortedMapPickler[K, V](implicit format: PickleFormat): SPickler[immutable.SortedMap[K, V]] with Unpickler[immutable.SortedMap[K, V]] = macro Compat.ImmSortedMapPicklerUnpicklerMacro_impl[K, V]
-  implicit def genMutMapPickler[K, V](implicit format: PickleFormat): SPickler[mutable.Map[K, V]] with Unpickler[mutable.Map[K, V]] = macro Compat.MutMapPicklerUnpicklerMacro_impl[K, V]
-
-}
-
-trait ArrayPicklerUnpicklerMacro extends CollectionPicklerUnpicklerMacro {
-  import c.universe._
-  import definitions._
-  lazy val ConsClass = c.mirror.staticClass("scala.Array")
-  def mkType(eltpe: c.Type) = appliedType(ConsClass.toTypeConstructor, List(eltpe))
-  def mkArray(picklee: c.Tree) = q"$picklee.toArray"
-  def mkBuffer(eltpe: c.Type) = q"scala.collection.mutable.ArrayBuffer[$eltpe]()"
-  def mkResult(buffer: c.Tree) = q"$buffer.toArray"
-}
-
-trait IterablePicklerUnpicklerMacro extends CollectionPicklerUnpicklerMacro {
-  import c.universe._
-  import definitions._
-  lazy val CollClass = c.mirror.staticClass("scala.Iterable")
-  def mkType(eltpe: c.Type) = appliedType(CollClass.toTypeConstructor, List(eltpe))
-  def mkArray(picklee: c.Tree) = q"$picklee.toArray"
-  def mkBuffer(eltpe: c.Type) = q"scala.collection.mutable.ListBuffer[$eltpe]()"
-  def mkResult(buffer: c.Tree) = q"$buffer.toSeq"
 }
 
 trait ListPicklerUnpicklerMacro extends CollectionPicklerUnpicklerMacro {
@@ -351,194 +310,4 @@ trait ListPicklerUnpicklerMacro extends CollectionPicklerUnpicklerMacro {
   def mkArray(picklee: c.Tree) = q"$picklee.toArray"
   def mkBuffer(eltpe: c.Type) = q"scala.collection.mutable.ListBuffer[$eltpe]()"
   def mkResult(buffer: c.Tree) = q"$buffer.toList"
-}
-
-trait ImmSetPicklerUnpicklerMacro extends CollectionPicklerUnpicklerMacro {
-  import c.universe._
-  import definitions._
-  lazy val CollClass = c.mirror.staticClass("scala.collection.immutable.Set")
-  def mkType(eltpe: c.Type) = appliedType(CollClass.toTypeConstructor, List(eltpe))
-  def mkArray(picklee: c.Tree) = q"$picklee.toArray"
-  def mkBuffer(eltpe: c.Type) = q"new scala.collection.mutable.SetBuilder[$eltpe, scala.collection.immutable.Set[$eltpe]](scala.collection.immutable.Set.empty[$eltpe])"
-  def mkResult(buffer: c.Tree) = q"$buffer.result"
-}
-
-trait ImmSortedSetPicklerUnpicklerMacro extends CollectionPicklerUnpicklerMacro {
-  import c.universe._
-  import definitions._
-  lazy val CollClass = c.mirror.staticClass("scala.collection.immutable.SortedSet")
-  def mkType(eltpe: c.Type) = appliedType(CollClass.toTypeConstructor, List(eltpe))
-  def mkArray(picklee: c.Tree) = q"$picklee.toArray"
-  def mkBuffer(eltpe: c.Type) = q"new scala.collection.mutable.SetBuilder[$eltpe, scala.collection.immutable.SortedSet[$eltpe]](scala.collection.immutable.SortedSet.empty[$eltpe])"
-  def mkResult(buffer: c.Tree) = q"$buffer.result"
-}
-
-trait MutSetPicklerUnpicklerMacro extends CollectionPicklerUnpicklerMacro {
-  import c.universe._
-  import definitions._
-  lazy val CollClass = c.mirror.staticClass("scala.collection.mutable.Set")
-  def mkType(eltpe: c.Type) = appliedType(CollClass.toTypeConstructor, List(eltpe))
-  def mkArray(picklee: c.Tree) = q"$picklee.toArray"
-  def mkBuffer(eltpe: c.Type) = q"new scala.collection.mutable.SetBuilder[$eltpe, scala.collection.mutable.Set[$eltpe]](scala.collection.mutable.Set.empty[$eltpe])"
-  def mkResult(buffer: c.Tree) = q"$buffer.result"
-}
-
-trait MutSortedSetPicklerUnpicklerMacro extends CollectionPicklerUnpicklerMacro {
-  import c.universe._
-  import definitions._
-  lazy val CollClass = c.mirror.staticClass("scala.collection.mutable.SortedSet")
-  def mkType(eltpe: c.Type) = appliedType(CollClass.toTypeConstructor, List(eltpe))
-  def mkArray(picklee: c.Tree) = q"$picklee.toArray"
-  def mkBuffer(eltpe: c.Type) = q"new scala.collection.mutable.SetBuilder[$eltpe, scala.collection.mutable.SortedSet[$eltpe]](scala.collection.mutable.SortedSet.empty[$eltpe])"
-  def mkResult(buffer: c.Tree) = q"$buffer.result"
-}
-
-trait ImmMapPicklerUnpicklerMacro extends MapPicklerUnpicklerMacro {
-  import c.universe._
-  import definitions._
-  lazy val CollClass = c.mirror.staticClass("scala.collection.immutable.Map")
-  def mkType(keytpe: c.Type, valtpe: c.Type) = appliedType(CollClass.toTypeConstructor, List(keytpe, valtpe))
-  def mkArray(picklee: c.Tree) = q"$picklee.toArray"
-  def mkBuffer(keytpe: c.Type, valtpe: c.Type) = q"new scala.collection.mutable.ListBuffer[($keytpe, $valtpe)]()"
-  def mkResult(buffer: c.Tree) = q"$buffer.toMap"
-}
-
-trait ImmSortedMapPicklerUnpicklerMacro extends MapPicklerUnpicklerMacro {
-  import c.universe._
-  import definitions._
-  lazy val CollClass = c.mirror.staticClass("scala.collection.immutable.SortedMap")
-  def mkType(keytpe: c.Type, valtpe: c.Type) = appliedType(CollClass.toTypeConstructor, List(keytpe, valtpe))
-  def mkArray(picklee: c.Tree) = q"$picklee.toArray"
-  def mkBuffer(keytpe: c.Type, valtpe: c.Type) = q"new scala.collection.mutable.MapBuilder[$keytpe, $valtpe, scala.collection.immutable.SortedMap[$keytpe, $valtpe]](scala.collection.immutable.SortedMap.empty[$keytpe, $valtpe])"
-  def mkResult(buffer: c.Tree) = q"$buffer.result"
-}
-
-trait MutMapPicklerUnpicklerMacro extends MapPicklerUnpicklerMacro {
-  import c.universe._
-  import definitions._
-  lazy val CollClass = c.mirror.staticClass("scala.collection.mutable.Map")
-  def mkType(keytpe: c.Type, valtpe: c.Type) = appliedType(CollClass.toTypeConstructor, List(keytpe, valtpe))
-  def mkArray(picklee: c.Tree) = q"$picklee.toArray"
-  def mkBuffer(keytpe: c.Type, valtpe: c.Type) = q"new scala.collection.mutable.MapBuilder[$keytpe, $valtpe, scala.collection.mutable.Map[$keytpe, $valtpe]](scala.collection.mutable.Map.empty[$keytpe, $valtpe])"
-  def mkResult(buffer: c.Tree) = q"$buffer.result"
-}
-
-trait MapPicklerUnpicklerMacro extends Macro {
-  def mkType(keytpe: c.Type, valtpe: c.Type): c.Type
-  def mkArray(picklee: c.Tree): c.Tree
-  def mkBuffer(keytpe: c.Type, valtpe: c.Type): c.Tree
-  def mkResult(buffer: c.Tree): c.Tree
-
-  def impl[K: c.WeakTypeTag, V: c.WeakTypeTag](format: c.Tree): c.Tree = {
-    import c.universe._
-    import definitions._
-
-    val keytpe = weakTypeOf[K]
-    val valtpe = weakTypeOf[V]
-    val tpe = mkType(keytpe, valtpe)
-    val eltpe = weakTypeOf[(K, V)]
-    val isPrimitive = eltpe.isEffectivelyPrimitive
-    val isFinal = eltpe.isEffectivelyFinal
-
-    val picklerUnpicklerName = c.fresh(syntheticPicklerUnpicklerName(tpe).toTermName)
-
-    q"""
-      implicit object $picklerUnpicklerName extends scala.pickling.SPickler[$tpe] with scala.pickling.Unpickler[$tpe] {
-        import scala.reflect.runtime.universe._
-        import scala.pickling._
-        import scala.pickling.`package`.PickleOps
-
-        val format = implicitly[${format.tpe}]
-
-        val elpickler: SPickler[$eltpe] = {
-          val elpickler = "bam!"
-          implicitly[SPickler[$eltpe]]
-        }
-        val elunpickler: Unpickler[$eltpe] = {
-          val elunpickler = "bam!"
-          implicitly[Unpickler[$eltpe]]
-        }
-        val eltag: scala.pickling.FastTypeTag[$eltpe] = {
-          val eltag = "bam!"
-          implicitly[scala.pickling.FastTypeTag[$eltpe]]
-        }
-        val colltag: scala.pickling.FastTypeTag[$tpe] = {
-          val colltag = "bam!"
-          implicitly[scala.pickling.FastTypeTag[$tpe]]
-        }
-
-        def pickle(picklee: $tpe, builder: PBuilder): Unit = {
-          builder.hintTag(colltag)
-          ${
-            if (eltpe =:= IntTpe) q"builder.hintKnownSize(picklee.length * 4 + 100)".asInstanceOf[Tree]
-            else q"".asInstanceOf[Tree]
-          }
-          builder.beginEntry(picklee)
-          ${
-            if (isPrimitive) q"builder.hintStaticallyElidedType(); builder.hintTag(eltag); builder.pinHints()".asInstanceOf[Tree]
-            else q"".asInstanceOf[Tree]
-          }
-          val arr = ${mkArray(q"picklee")}
-          val length = arr.length
-          builder.beginCollection(arr.length)
-          var i = 0
-          while (i < arr.length) {
-            builder putElement { b =>
-              ${
-                if (!isPrimitive && !isFinal) q"""
-                  b.hintTag(eltag)
-                  arr(i).pickleInto(b)
-                """.asInstanceOf[Tree] else if (!isPrimitive && isFinal) q"""
-                  b.hintTag(eltag)
-                  b.hintStaticallyElidedType()
-                  arr(i).pickleInto(b)
-                """.asInstanceOf[Tree] else q"""
-                  elpickler.pickle(arr(i), b)
-                """.asInstanceOf[Tree]
-              }
-            }
-            i += 1
-          }
-          ${
-            if (isPrimitive) q"builder.unpinHints()".asInstanceOf[Tree]
-            else q"".asInstanceOf[Tree]
-          }
-          builder.endCollection(i)
-          builder.endEntry()
-        }
-        def unpickle(tag: => scala.pickling.FastTypeTag[_], reader: PReader): Any = {
-          val arrReader = reader.beginCollection()
-          ${
-            if (isPrimitive) q"arrReader.hintStaticallyElidedType(); arrReader.hintTag(eltag); arrReader.pinHints()".asInstanceOf[Tree]
-            else q"".asInstanceOf[Tree]
-          }
-          val length = arrReader.readLength()
-          var buffer = ${mkBuffer(keytpe, valtpe)}
-          var i = 0
-          while (i < length) {
-            val r = arrReader.readElement()
-            ${
-              if (isPrimitive) q"""
-                r.beginEntryNoTag()
-                val elem = elunpickler.unpickle(eltag, r).asInstanceOf[$eltpe]
-                r.endEntry()
-                buffer += elem
-              """.asInstanceOf[Tree] else q"""
-                val elem = r.unpickle[$eltpe]
-                buffer += elem
-              """.asInstanceOf[Tree]
-            }
-            i += 1
-          }
-          ${
-            if (isPrimitive) q"arrReader.unpinHints()".asInstanceOf[Tree]
-            else q"".asInstanceOf[Tree]
-          }
-          arrReader.endCollection()
-          ${mkResult(q"buffer")}
-        }
-      }
-      $picklerUnpicklerName
-    """
-  }
 }


### PR DESCRIPTION
Temporarily left out list pickler due to filename too long IO errors (next on the list for fixing)
