### PR TITLE
Makes object identity checking threadsafe, closes #45

### DIFF
--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -103,32 +103,65 @@ package object pickling {
     }
   }
 
-  private var picklees = new ReactMap
-  private var nextPicklee = 0
+  // private var picklees = new ReactMap
+  // private var nextPicklee = 0
+  val pickleesTL = new ThreadLocal[ReactMap] {
+    override def initialValue() = new ReactMap
+  }
+  val nextPickleeTL = new ThreadLocal[Int] {
+    override def initialValue() = 0
+  }
+
   def lookupPicklee(picklee: Any) = {
+    var nextPicklee = nextPickleeTL.get()
+    val picklees = pickleesTL.get()
+
     val index = nextPicklee
     val result = picklees.insertIfNotThere(picklee.asInstanceOf[AnyRef], index)
     // println(s"lookupPicklee($picklee) = $result")
-    if (result == -1)
+    if (result == -1) {
       nextPicklee += 1
+      nextPickleeTL.set(nextPicklee)
+    }
+    pickleesTL.set(picklees)
     result
   }
   def registerPicklee(picklee: Any) = {
+    var nextPicklee = nextPickleeTL.get()
+    val picklees = pickleesTL.get()
+
     val index = nextPicklee
     picklees.insert(picklee.asInstanceOf[AnyRef], index)
     // println(s"registerPicklee($picklee, $index)")
     nextPicklee += 1
+    nextPickleeTL.set(nextPicklee)
+    pickleesTL.set(picklees)
     index
   }
   def clearPicklees() = {
+    var nextPicklee = nextPickleeTL.get()
+    val picklees = pickleesTL.get()
+
     picklees.clear()
     nextPicklee = 0
+
+    nextPickleeTL.set(nextPicklee)
+    pickleesTL.set(picklees)
   }
 
-  private var unpicklees = new Array[Any](65536)
-  private var nextUnpicklee = 0
+  // private var unpicklees = new Array[Any](65536)
+  // private var nextUnpicklee = 0
+  val unpickleesTL = new ThreadLocal[Array[Any]] {
+    override def initialValue() = new Array[Any](65536)
+  }
+  val nextUnpickleeTL = new ThreadLocal[Int] {
+    override def initialValue() = 0
+  }
 
   def lookupUnpicklee(index: Int): Any = {
+    val nextUnpicklee = nextUnpickleeTL.get()
+    val unpicklees = unpickleesTL.get()
+
     // println(s"lookupUnpicklee($index)")
     if (index >= nextUnpicklee) throw new Error(s"fatal error: invalid index $index in unpicklee cache of length $nextUnpicklee")
     val result = unpicklees(index)
@@ -136,23 +169,36 @@ package object pickling {
     result
   }
   def preregisterUnpicklee() = {
+    var nextUnpicklee = nextUnpickleeTL.get()
+    val unpicklees = unpickleesTL.get()
+
     val index = nextUnpicklee
     // TODO: dynamically resize the array!
     unpicklees(index) = null
     // println(s"preregisterUnpicklee() at $index")
     nextUnpicklee += 1
+    nextUnpickleeTL.set(nextUnpicklee)
+    unpickleesTL.set(unpicklees)
     index
   }
   def registerUnpicklee(unpicklee: Any, index: Int) = {
+    val unpicklees = unpickleesTL.get()
+
     // println(s"registerUnpicklee($unpicklee, $index)")
     unpicklees(index) = unpicklee
+    unpickleesTL.set(unpicklees)
   }
   def clearUnpicklees() = {
+    var nextUnpicklee = nextUnpickleeTL.get()
+    val unpicklees = unpickleesTL.get()
+
     var i = 0
     while (i < nextUnpicklee) {
       unpicklees(i) = null
       i += 1
     }
     nextUnpicklee = 0
+    nextUnpickleeTL.set(nextUnpicklee)
+    unpickleesTL.set(unpicklees)
   }
 }

--- a/core/src/test/scala/pickling/object-graph-threadsafety.scala.disabled
+++ b/core/src/test/scala/pickling/object-graph-threadsafety.scala.disabled
@@ -1,0 +1,70 @@
+package scala.pickling.`object`.graph.threadsafety
+
+import org.scalatest.FunSuite
+import scala.pickling._
+import json._
+
+class C(val name: String, val desc: String, var c: C, val arr: Array[Int])
+
+class ThreadsafetyTest extends FunSuite {
+  val c1 = new C("c1", "desc", null, Array(1))
+  val c2 = new C("c2", "desc", c1, Array(1))
+  val c3 = new C("c3", "desc", c2, Array(1))
+  c1.c = c3
+
+  test("object-graph-threadsafety") {
+    val r = new Runnable {
+      def run() = {
+        for (_ <- 1 to 100) {
+          val pickle = c1.pickle
+          assert(pickle.toString === """
+            |JSONPickle({
+            |  "tpe": "scala.pickling.share.json.C",
+            |  "name": "c1",
+            |  "desc": "desc",
+            |  "arr": [
+            |    1
+            |  ],
+            |  "c": {
+            |    "name": "c3",
+            |    "desc": "desc",
+            |    "arr": [
+            |      1
+            |    ],
+            |    "c": {
+            |      "name": "c2",
+            |      "desc": "desc",
+            |      "arr": [
+            |        1
+            |      ],
+            |      "c": { "$ref": 0 }
+            |    }
+            |  }
+            |})
+          """.trim.stripMargin)
+
+          val c11 = pickle.unpickle[C]
+          val c13 = c11.c
+          val c12 = c13.c
+          assert(c11.name === "c1")
+          assert(c11.desc === "desc")
+          assert(c11.arr.toList === List(1))
+          assert(c12.name === "c2")
+          assert(c12.desc === "desc")
+          assert(c12.arr.toList === List(1))
+          assert(c13.name === "c3")
+          assert(c13.desc === "desc")
+          assert(c13.arr.toList === List(1))
+          assert(c12.c === c11)
+        }
+      }
+    }
+
+    val t1 = new Thread(r)
+    val t2 = new Thread(r)
+    t1.start
+    t2.start
+    t1.join
+    t2.join
+  }
+}


### PR DESCRIPTION
Additionally included is a thread safety test which we unfortunately can't make use of at the moment due to the fact that Scala reflection is currently not thread safe on Scala 2.10.x. 

Fortunately, we're only a week or so away from thread safe reflection fully merged into scala/master. This means that folks running scala/pickling on 2.11 milestones beginning with 2.11-M7 will not have this limitation.
