### PR TITLE
Fix #36 - BigDecimal unpickling doesn't work

### DIFF
--- a/core/src/main/scala/pickling/Custom.scala
+++ b/core/src/main/scala/pickling/Custom.scala
@@ -272,6 +272,34 @@ trait CollectionPicklerUnpicklerMacro extends Macro {
 }
 
 trait CorePicklersUnpicklers extends GenPicklers with GenUnpicklers with LowPriorityPicklersUnpicklers {
+  import java.math.BigDecimal
+
+  implicit object BigDecimalPicklerUnpickler extends SPickler[BigDecimal] with Unpickler[BigDecimal] {
+    val format = null // not used
+    def pickle(picklee: BigDecimal, builder: PBuilder): Unit = {
+      builder.beginEntry(picklee)
+
+      builder.putField("value", b => {
+        b.hintTag(implicitly[FastTypeTag[String]])
+        b.hintStaticallyElidedType()
+        stringPicklerUnpickler.pickle(picklee.toString, b)
+      })
+
+      builder.endEntry()
+    }
+    def unpickle(tag: => FastTypeTag[_], reader: PReader): Any = {
+      val reader1 = reader.readField("value")
+      reader1.hintTag(implicitly[FastTypeTag[String]])
+      reader1.hintStaticallyElidedType()
+
+      val tag = reader1.beginEntry()
+      val result = stringPicklerUnpickler.unpickle(tag, reader1)
+      reader1.endEntry()
+
+      new BigDecimal(result.asInstanceOf[String])
+    }
+  }
+
   class PrimitivePicklerUnpickler[T] extends SPickler[T] with Unpickler[T] {
     val format = null // not used
     def pickle(picklee: T, builder: PBuilder): Unit = {

--- a/core/src/test/scala/pickling/pickling-spec.scala
+++ b/core/src/test/scala/pickling/pickling-spec.scala
@@ -7,6 +7,8 @@ import org.scalacheck.Prop.forAll
 import Gen._
 import Arbitrary.arbitrary
 
+import java.math.BigDecimal
+
 object PicklingSpec {
   sealed abstract class Base
   final class C(s: String) extends Base { override def toString = "C" }
@@ -233,6 +235,13 @@ object PicklingJsonSpec extends Properties("pickling-json") {
     val readArr = pickle.unpickle[Array[Double]]
     readArr.sameElements(ia)
   })
+
+  property("BigDecimal") = Prop forAll { (x: Double) =>
+    val bd = new BigDecimal(x)
+    val pickle: JSONPickle = bd.pickle
+    val x1 = pickle.unpickle[BigDecimal]
+    x1 == bd
+  }
 }
 
 
@@ -437,4 +446,11 @@ object PicklingBinarySpec extends Properties("pickling-binary") {
     val readArr = pickle.unpickle[Array[Double]]
     readArr.sameElements(ia)
   })
+
+  property("BigDecimal") = Prop forAll { (x: Double) =>
+    val bd = new BigDecimal(x)
+    val pickle: BinaryPickle = bd.pickle
+    val x1 = pickle.unpickle[BigDecimal]
+    x1 == bd
+  }
 }


### PR DESCRIPTION
Adds custom pickler/unpickler. Adds tests to PicklingJsonSpec and
PicklingBinarySpec.
