### PR TITLE
Create a new SimpleDataFormat instance per invocation as the SimpleDateFormat class is not thread safe.

### DIFF
--- a/core/src/main/scala/pickling/Custom.scala
+++ b/core/src/main/scala/pickling/Custom.scala
@@ -332,12 +332,13 @@ trait CorePicklersUnpicklers extends GenPicklers with GenUnpicklers with LowPrio
   }
 
   implicit object DatePicklerUnpickler extends SPickler[Date] with Unpickler[Date] {
-    private def dateFormat = {
+    private val dateFormatTemplate = {
       val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") //use ISO_8601 format
       format.setLenient(false)
       format.setTimeZone(TimeZone.getTimeZone("UTC"))
       format
     }
+    private def dateFormat = dateFormatTemplate.clone.asInstanceOf[SimpleDateFormat]
 
     val format = null // not used
     def pickle(picklee: Date, builder: PBuilder): Unit = {


### PR DESCRIPTION
As per the subject, see also @alex-berger's comments on #62

Turning dateFormat into a function seemed preferable to duplicating the instantiation code.
