### PR TITLE
Fix for issue #66

### DIFF
--- a/core/src/main/scala/pickling/Output.scala
+++ b/core/src/main/scala/pickling/Output.scala
@@ -14,18 +14,15 @@ trait Output[T] {
 
 // encoded primitives: Byte, Short, Char, Int, Long, Boolean, String
 // encoded primitive arrays: Array[Byte], Array[Int]
-// Q: why do the "AtEnd" methods also take a "pos"? Isn't it always ignored?
 
 trait EncodingOutput[T] extends Output[T] {
-  def encodeByteTo(pos: Int, value: Byte): Int
-  def encodeByteAtEnd(pos: Int, value: Byte): Unit
-  def encodeShortAtEnd(pos: Int, value: Short): Unit
-  def encodeCharAtEnd(pos: Int, value: Char): Unit
-  def encodeIntAtEnd(pos: Int, value: Int): Unit
-  def encodeLongAtEnd(pos: Int, value: Long): Unit
-  def encodeIntTo(pos: Int, value: Int): Int
+  def encodeByteTo(pos: Int, value: Byte): Unit
+  def encodeShortTo(pos: Int, value: Short): Unit
+  def encodeCharTo(pos: Int, value: Char): Unit
+  def encodeIntTo(pos: Int, value: Int): Unit
+  def encodeLongTo(pos: Int, value: Long): Unit
+  def encodeBooleanTo(pos: Int, value: Boolean): Unit
   def encodeStringTo(pos: Int, value: String): Int
-  def encodeBooleanTo(pos: Int, value: Boolean): Int
   def encodeByteArrayTo(pos: Int, ia: Array[Byte]): Int
   def encodeShortArrayTo(pos: Int, ia: Array[Short]): Int
   def encodeCharArrayTo(pos: Int, ia: Array[Char]): Int
@@ -34,7 +31,7 @@ trait EncodingOutput[T] extends Output[T] {
   def encodeBooleanArrayTo(pos: Int, ia: Array[Boolean]): Int
   def encodeFloatArrayTo(pos: Int, ia: Array[Float]): Int
   def encodeDoubleArrayTo(pos: Int, ia: Array[Double]): Int
-  def copyTo(pos: Int, bytes: Array[Byte]): Int
+  def copyTo(pos: Int, bytes: Array[Byte]): Unit
 }
 
 

--- a/core/src/main/scala/pickling/binary/ByteBuffer.scala
+++ b/core/src/main/scala/pickling/binary/ByteBuffer.scala
@@ -4,23 +4,19 @@ import scala.collection.mutable.ArrayBuffer
 import scala.pickling.EncodingOutput
 
 sealed abstract class ByteBuffer extends EncodingOutput[Array[Byte]] {
-  def encodeByteTo(pos: Int, value: Byte): Int
+  def encodeByteTo(pos: Int, value: Byte): Unit
 
-  def encodeByteAtEnd(pos: Int, value: Byte): Unit
+  def encodeShortTo(pos: Int, value: Short): Unit
 
-  def encodeShortAtEnd(pos: Int, value: Short): Unit
+  def encodeCharTo(pos: Int, value: Char): Unit
 
-  def encodeCharAtEnd(pos: Int, value: Char): Unit
+  def encodeIntTo(pos: Int, value: Int): Unit
 
-  def encodeIntAtEnd(pos: Int, value: Int): Unit
-
-  def encodeLongAtEnd(pos: Int, value: Long): Unit
-
-  def encodeIntTo(pos: Int, value: Int): Int
+  def encodeLongTo(pos: Int, value: Long): Unit
 
   def encodeStringTo(pos: Int, value: String): Int
 
-  def encodeBooleanTo(pos: Int, value: Boolean): Int
+  def encodeBooleanTo(pos: Int, value: Boolean): Unit
 
   def encodeByteArrayTo(pos: Int, ia: Array[Byte]): Int
 
@@ -38,7 +34,7 @@ sealed abstract class ByteBuffer extends EncodingOutput[Array[Byte]] {
 
   def encodeDoubleArrayTo(pos: Int, ia: Array[Double]): Int
 
-  def copyTo(pos: Int, bytes: Array[Byte]): Int
+  def copyTo(pos: Int, bytes: Array[Byte]): Unit
 
   def decodeByteFrom(pos: Int): Byte
 
@@ -87,114 +83,56 @@ final class ByteArray(arr: Array[Byte]) extends ByteBuffer {
     this(Array.ofDim[Byte](size))
   }
 
-  def encodeByteTo(pos: Int, value: Byte): Int = {
-    arr(pos) = value
-    pos + 1
-  }
-
-  def encodeByteAtEnd(pos: Int, value: Byte): Unit =
+  def encodeByteTo(pos: Int, value: Byte): Unit =
     arr(pos) = value
 
-  def encodeShortAtEnd(pos: Int, value: Short): Unit =
+  def encodeShortTo(pos: Int, value: Short): Unit =
     Util.encodeShortTo(arr, pos, value)
 
-  def encodeCharAtEnd(pos: Int, value: Char): Unit =
+  def encodeCharTo(pos: Int, value: Char): Unit =
     Util.encodeCharTo(arr, pos, value)
 
-  def encodeIntAtEnd(pos: Int, value: Int): Unit =
-    Util.encodeIntTo(arr, pos, value)
-
-  def encodeLongAtEnd(pos: Int, value: Long): Unit =
+  def encodeLongTo(pos: Int, value: Long): Unit =
     Util.encodeLongTo(arr, pos, value)
 
-  def encodeIntTo(pos: Int, value: Int): Int =
+  def encodeIntTo(pos: Int, value: Int): Unit =
     Util.encodeIntTo(arr, pos, value)
 
   def encodeStringTo(pos: Int, value: String): Int =
     Util.encodeStringTo(arr, pos, value)
 
-  def encodeBooleanTo(pos: Int, value: Boolean): Int =
+  def encodeBooleanTo(pos: Int, value: Boolean): Unit =
     Util.encodeBooleanTo(arr, pos, value)
 
-  def encodeByteArrayTo(pos: Int, ia: Array[Byte]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, arr, destOffset + newpos, ia.length * 1)
-    newpos + ia.length * 1
-  }
+  def encodeByteArrayTo(pos: Int, ia: Array[Byte]): Int =
+    Util.encodeByteArrayTo(arr, pos, ia)
 
-  def encodeShortArrayTo(pos: Int, ia: Array[Short]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val srcOffset = UnsafeMemory.shortArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, arr, destOffset + newpos, ia.length * 2)
-    newpos + ia.length * 2
-  }
+  def encodeShortArrayTo(pos: Int, ia: Array[Short]): Int =
+    Util.encodeShortArrayTo(arr, pos, ia)
 
-  def encodeCharArrayTo(pos: Int, ia: Array[Char]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val srcOffset = UnsafeMemory.charArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, arr, destOffset + newpos, ia.length * 2)
-    newpos + ia.length * 2
-  }
+  def encodeCharArrayTo(pos: Int, ia: Array[Char]): Int =
+    Util.encodeCharArrayTo(arr, pos, ia)
 
-  def encodeIntArrayTo(pos: Int, ia: Array[Int]): Int = {
-    // no bounds check
+  def encodeIntArrayTo(pos: Int, ia: Array[Int]): Int =
+    Util.encodeIntArrayTo(arr, pos, ia)
 
-    // 1. store length of array
-    val newpos = encodeIntTo(pos, ia.length)
+  def encodeLongArrayTo(pos: Int, ia: Array[Long]): Int =
+    Util.encodeLongArrayTo(arr, pos, ia)
 
-    // 2. copy memory
-    val srcOffset = UnsafeMemory.intArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    // copy ia into arr
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, arr, destOffset + newpos, ia.length * 4)
+  def encodeBooleanArrayTo(pos: Int, ia: Array[Boolean]): Int =
+    Util.encodeBooleanArrayTo(arr, pos, ia)
 
-    newpos + ia.length * 4
-  }
+  def encodeFloatArrayTo(pos: Int, ia: Array[Float]): Int =
+    Util.encodeFloatArrayTo(arr, pos, ia)
 
-  def encodeLongArrayTo(pos: Int, ia: Array[Long]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val srcOffset = UnsafeMemory.longArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, arr, destOffset + newpos, ia.length * 8)
-    newpos + ia.length * 8
-  }
+  def encodeDoubleArrayTo(pos: Int, ia: Array[Double]): Int =
+    Util.encodeDoubleArrayTo(arr, pos, ia)
 
-  def encodeBooleanArrayTo(pos: Int, ia: Array[Boolean]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val srcOffset = UnsafeMemory.booleanArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, arr, destOffset + newpos, ia.length * 1)
-    newpos + ia.length * 1
-  }
-
-  def encodeFloatArrayTo(pos: Int, ia: Array[Float]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val srcOffset = UnsafeMemory.floatArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, arr, destOffset + newpos, ia.length * 4)
-    newpos + ia.length * 4
-  }
-
-  def encodeDoubleArrayTo(pos: Int, ia: Array[Double]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val srcOffset = UnsafeMemory.doubleArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, arr, destOffset + newpos, ia.length * 8)
-    newpos + ia.length * 8
-  }
-
-  def copyTo(pos: Int, bytes: Array[Byte]): Int = {
+  def copyTo(pos: Int, bytes: Array[Byte]): Unit =
     Util.copy(arr, pos, bytes)
-    pos + bytes.length
-  }
 
-  def decodeByteFrom(pos: Int): Byte = {
+  def decodeByteFrom(pos: Int): Byte =
     arr(pos)
-  }
 
   def decodeShortFrom(pos: Int): Short =
     Util.decodeShortFrom(arr, pos)
@@ -214,92 +152,29 @@ final class ByteArray(arr: Array[Byte]) extends ByteBuffer {
   def decodeBooleanFrom(pos: Int): Boolean =
     Util.decodeBooleanFrom(arr, pos)
 
-  def decodeByteArrayFrom(pos: Int): (Array[Byte], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Byte](len)
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.intArrayOffset
-    UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 1)
-    (ia, nextPos + len * 1)
-  }
+  def decodeByteArrayFrom(pos: Int): (Array[Byte], Int) =
+    Util.decodeByteArrayFrom(arr, pos)
 
-  def decodeShortArrayFrom(pos: Int): (Array[Short], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Short](len)
-    val srcOffset = UnsafeMemory.shortArrayOffset
-    val destOffset = UnsafeMemory.intArrayOffset
-    UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 2)
-    (ia, nextPos + len * 2)
-  }
+  def decodeShortArrayFrom(pos: Int): (Array[Short], Int) =
+    Util.decodeShortArrayFrom(arr, pos)
 
-  def decodeCharArrayFrom(pos: Int): (Array[Char], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Char](len)
-    val srcOffset = UnsafeMemory.charArrayOffset
-    val destOffset = UnsafeMemory.intArrayOffset
-    UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 2)
-    (ia, nextPos + len * 2)
-  }
+  def decodeCharArrayFrom(pos: Int): (Array[Char], Int) =
+    Util.decodeCharArrayFrom(arr, pos)
 
-  def decodeIntArrayFrom(pos: Int): (Array[Int], Int) = {
-    // arr: Array[Byte]
-    // 1. read length
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
+  def decodeIntArrayFrom(pos: Int): (Array[Int], Int) =
+    Util.decodeIntArrayFrom(arr, pos)
 
-    // 2. allocate Array[Int] TODO: use Unsafe
-    val ia = Array.ofDim[Int](len)
+  def decodeLongArrayFrom(pos: Int): (Array[Long], Int) =
+    Util.decodeLongArrayFrom(arr, pos)
 
-    // 3. the copy
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.intArrayOffset
-    UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 4)
+  def decodeBooleanArrayFrom(pos: Int): (Array[Boolean], Int) =
+    Util.decodeBooleanArrayFrom(arr, pos)
 
-    (ia, nextPos + len * 4)
-  }
+  def decodeFloatArrayFrom(pos: Int): (Array[Float], Int) =
+    Util.decodeFloatArrayFrom(arr, pos)
 
-  def decodeLongArrayFrom(pos: Int): (Array[Long], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Long](len)
-    val srcOffset = UnsafeMemory.longArrayOffset
-    val destOffset = UnsafeMemory.intArrayOffset
-    UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 8)
-    (ia, nextPos + len * 8)
-  }
-
-  def decodeBooleanArrayFrom(pos: Int): (Array[Boolean], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Boolean](len)
-    val srcOffset = UnsafeMemory.booleanArrayOffset
-    val destOffset = UnsafeMemory.intArrayOffset
-    UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 1)
-    (ia, nextPos + len * 1)
-  }
-
-  def decodeFloatArrayFrom(pos: Int): (Array[Float], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Float](len)
-    val srcOffset = UnsafeMemory.floatArrayOffset
-    val destOffset = UnsafeMemory.intArrayOffset
-    UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 4)
-    (ia, nextPos + len * 4)
-  }
-
-  def decodeDoubleArrayFrom(pos: Int): (Array[Double], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Double](len)
-    val srcOffset = UnsafeMemory.doubleArrayOffset
-    val destOffset = UnsafeMemory.intArrayOffset
-    UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 8)
-    (ia, nextPos + len * 8)
-  }
+  def decodeDoubleArrayFrom(pos: Int): (Array[Double], Int) =
+    Util.decodeDoubleArrayFrom(arr, pos)
 
   def toArray: Array[Byte] =
     arr
@@ -311,22 +186,13 @@ final class ByteArrayBuffer extends ByteBuffer {
 
   private val buf = ArrayBuffer[Byte]()
 
-  def encodeByteTo(pos: Int, value: Byte): Int = {
-    if (buf.size < pos + 1) {
-      val missing = pos + 1 - buf.size
-      buf ++= Array.ofDim[Byte](missing)
-    }
-    buf(pos) = value
-    pos + 1
-  }
-
   // pos is ignored!
-  def encodeByteAtEnd(pos: Int, value: Byte): Unit = {
+  def encodeByteTo(pos: Int, value: Byte): Unit = {
     buf += value
   }
 
   // pos is ignored!
-  def encodeShortAtEnd(pos: Int, value: Short): Unit = {
+  def encodeShortTo(pos: Int, value: Short): Unit = {
     val fst = (value >>> 8 & 0xff).asInstanceOf[Byte]
     val snd = (value & 0xff).asInstanceOf[Byte]
     buf += fst
@@ -334,7 +200,7 @@ final class ByteArrayBuffer extends ByteBuffer {
   }
 
   // pos is ignored!
-  def encodeCharAtEnd(pos: Int, value: Char): Unit = {
+  def encodeCharTo(pos: Int, value: Char): Unit = {
     val fst = (value >>> 8 & 0xff).asInstanceOf[Byte]
     val snd = (value & 0xff).asInstanceOf[Byte]
     buf += fst
@@ -342,8 +208,8 @@ final class ByteArrayBuffer extends ByteBuffer {
   }
 
   // pos is ignored!
-  def encodeIntAtEnd(pos: Int, value: Int): Unit = {
-    // assert(buf.size == pos)
+  def encodeIntTo(pos: Int, value: Int): Unit = {
+    assert(buf.size == pos)
     val fst = (value >>> 24).asInstanceOf[Byte]
     val snd = (value >>> 16 & 0xff).asInstanceOf[Byte]
     val thrd = (value >>> 8 & 0xff).asInstanceOf[Byte]
@@ -355,7 +221,7 @@ final class ByteArrayBuffer extends ByteBuffer {
   }
 
   // pos is ignored!
-  def encodeLongAtEnd(pos: Int, value: Long): Unit = {
+  def encodeLongTo(pos: Int, value: Long): Unit = {
     val elem1 = (value >>> 56 & 0xff).asInstanceOf[Byte]
     val elem2 = (value >>> 48 & 0xff).asInstanceOf[Byte]
     val elem3 = (value >>> 40 & 0xff).asInstanceOf[Byte]
@@ -374,281 +240,122 @@ final class ByteArrayBuffer extends ByteBuffer {
     buf += elem8
   }
 
-  def encodeIntTo(pos: Int, value: Int): Int = {
-    if (buf.size < pos + 4) {
-      val missing = pos + 4 - buf.size
-      buf ++= Array.ofDim[Byte](missing)
-    }
-    Util.encodeIntTo(buf, pos, value)
-    pos + 4
-  }
-
   def encodeStringTo(pos: Int, value: String): Int = {
     // assume pos == buf.size
     val bytes = value.getBytes("UTF-8")
     val len   = bytes.length
-    val next  = encodeIntTo(pos, len)
+    encodeIntTo(pos, len)
     buf ++= bytes
-    next + len
+    pos + 4 + len
   }
 
-  def encodeBooleanTo(pos: Int, value: Boolean): Int = {
-    if (buf.size <= pos) buf += 0
-    buf(pos) = if (value) 1 else 0
-    pos + 1
+  def encodeBooleanTo(pos: Int, value: Boolean): Unit = {
+    buf += (if (value) 1 else 0)
   }
 
   def encodeByteArrayTo(pos: Int, ia: Array[Byte]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val ba = Array.ofDim[Byte](ia.length * 1)
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, ba, destOffset, ia.length * 1)
+    val ba = Array.ofDim[Byte](4 + ia.length * 1)
+    val newpos = Util.encodeByteArrayTo(ba, 0, ia)
     buf ++= ba
-    newpos + ia.length * 1
+    pos + newpos
   }
 
   def encodeShortArrayTo(pos: Int, ia: Array[Short]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val ba = Array.ofDim[Byte](ia.length * 2)
-    val srcOffset = UnsafeMemory.shortArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, ba, destOffset, ia.length * 2)
+    val ba = Array.ofDim[Byte](4 + ia.length * 2)
+    val newpos = Util.encodeShortArrayTo(ba, 0, ia)
     buf ++= ba
-    newpos + ia.length * 2
+    pos + newpos
   }
 
   def encodeCharArrayTo(pos: Int, ia: Array[Char]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val ba = Array.ofDim[Byte](ia.length * 2)
-    val srcOffset = UnsafeMemory.charArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, ba, destOffset, ia.length * 2)
+    val ba = Array.ofDim[Byte](4 + ia.length * 2)
+    val newpos = Util.encodeCharArrayTo(ba, 0, ia)
     buf ++= ba
-    newpos + ia.length * 2
+    pos + newpos
   }
 
   def encodeIntArrayTo(pos: Int, ia: Array[Int]): Int = {
-    // no bounds check
-
-    // 1. store length of array
-    val newpos = encodeIntTo(pos, ia.length)
-
-    // 2. allocate temp byte array
-    val ba = Array.ofDim[Byte](ia.length * 4)
-
-    // 2. copy memory
-    val srcOffset = UnsafeMemory.intArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-
-    // copy ia into ba
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, ba, destOffset, ia.length * 4)
-
-    // 3. concatenate temp byte array to buf
+    val ba = Array.ofDim[Byte](4 + ia.length * 4)
+    val newpos = Util.encodeIntArrayTo(ba, 0, ia)
     buf ++= ba
-
-    newpos + ia.length * 4
+    pos + newpos
   }
 
   def encodeLongArrayTo(pos: Int, ia: Array[Long]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val ba = Array.ofDim[Byte](ia.length * 8)
-    val srcOffset = UnsafeMemory.charArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, ba, destOffset, ia.length * 8)
+    val ba = Array.ofDim[Byte](4 + ia.length * 8)
+    val newpos = Util.encodeLongArrayTo(ba, 0, ia)
     buf ++= ba
-    newpos + ia.length * 8
+    pos + newpos
   }
 
   def encodeBooleanArrayTo(pos: Int, ia: Array[Boolean]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val ba = Array.ofDim[Byte](ia.length * 1)
-    val srcOffset = UnsafeMemory.booleanArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, ba, destOffset, ia.length * 1)
+    val ba = Array.ofDim[Byte](4 + ia.length * 1)
+    val newpos = Util.encodeBooleanArrayTo(ba, 0, ia)
     buf ++= ba
-    newpos + ia.length * 1
+    pos + newpos
   }
 
   def encodeFloatArrayTo(pos: Int, ia: Array[Float]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val ba = Array.ofDim[Byte](ia.length * 4)
-    val srcOffset = UnsafeMemory.floatArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, ba, destOffset, ia.length * 4)
+    val ba = Array.ofDim[Byte](4 + ia.length * 4)
+    val newpos = Util.encodeFloatArrayTo(ba, 0, ia)
     buf ++= ba
-    newpos + ia.length * 4
+    pos + newpos
   }
 
   def encodeDoubleArrayTo(pos: Int, ia: Array[Double]): Int = {
-    val newpos = encodeIntTo(pos, ia.length)
-    val ba = Array.ofDim[Byte](ia.length * 8)
-    val srcOffset = UnsafeMemory.doubleArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    UnsafeMemory.unsafe.copyMemory(ia, srcOffset, ba, destOffset, ia.length * 8)
+    val ba = Array.ofDim[Byte](4 + ia.length * 8)
+    val newpos = Util.encodeDoubleArrayTo(ba, 0, ia)
     buf ++= ba
-    newpos + ia.length * 8
+    pos + newpos
   }
 
-  def copyTo(pos: Int, bytes: Array[Byte]): Int = {
-    // assume buf.size = buf
+  def copyTo(pos: Int, bytes: Array[Byte]): Unit =
     buf ++= bytes
-    pos + bytes.length
-  }
 
-  def decodeByteFrom(pos: Int): Byte = {
-    buf(pos)
-  }
+  def decodeByteFrom(pos: Int): Byte =
+    ???
 
-  def decodeShortFrom(pos: Int): Short = {
-    val fst = ((buf(pos) << 8) & 0xFFFF).toShort
-    val snd = (buf(pos+1)      & 0x00FF).toShort
-    (fst | snd).toShort
-  }
+  def decodeShortFrom(pos: Int): Short =
+    ???
 
-  def decodeCharFrom(pos: Int): Char = {
-    val fst = ((buf(pos) << 8) & 0xFFFF).toChar
-    val snd = (buf(pos+1)      & 0x00FF).toChar
-    (fst | snd).toChar
-  }
+  def decodeCharFrom(pos: Int): Char =
+    ???
 
-  def decodeIntFrom(pos: Int): Int = {
-    val fst = (buf(pos) << 24).toInt
-    val snd = ((buf(pos+1) << 16) & 0x00FFFFFF).toInt
-    val thrd = ((buf(pos+2) << 8) & 0x0000FFFF).toInt
-    val frth = (buf(pos+3) & 0x000000FF).toInt
-    fst | snd | thrd | frth
-  }
+  def decodeIntFrom(pos: Int): Int =
+    ???
 
-  def decodeLongFrom(pos: Int): Long = {
-    val elem1 = ((buf(pos) << 56)   & 0xFFFFFFFFFFFFFFFFL).toLong
-    val elem2 = ((buf(pos+1) << 48) & 0xFFFFFFFFFFFFFFL).toLong
-    val elem3 = ((buf(pos+2) << 40) & 0xFFFFFFFFFFFFL).toLong
-    val elem4 = ((buf(pos+3) << 32) & 0xFFFFFFFFFFL).toLong
-    val elem5 = ((buf(pos+4) << 24) & 0xFFFFFFFF).toLong
-    val elem6 = ((buf(pos+5) << 16) & 0x00FFFFFF).toLong
-    val elem7 = ((buf(pos+6) << 8) & 0x0000FFFF).toLong
-    val elem8 = (buf(pos+7) & 0x000000FF).toLong
-    elem1 | elem2 | elem3 | elem4 | elem5 | elem6 | elem7 | elem8
-  }
+  def decodeLongFrom(pos: Int): Long =
+    ???
 
-  def decodeStringFrom(pos: Int): (String, Int) = {
-    val len = decodeIntFrom(pos)
-    println(s"decoding string of length $len, starting from ${pos+4}")
-    val bytes = buf.slice(pos + 4, pos + 4 + len).toArray
-    println("bytes: " + bytes.mkString(","))
-    val res = new String(bytes, "UTF-8")
-    println(s"result string: $res")
-    (res, pos + 4 + len)
-  }
+  def decodeStringFrom(pos: Int): (String, Int) =
+    ???
 
-  def decodeBooleanFrom(pos: Int): Boolean = {
-    decodeByteFrom(pos) != 0
-  }
+  def decodeBooleanFrom(pos: Int): Boolean =
+    ???
 
-  def decodeByteArrayFrom(pos: Int): (Array[Byte], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Byte](len)
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.byteArrayOffset
-    val newbuf = buf.slice(nextPos, nextPos + len * 1)
-    val ba: Array[Byte] = newbuf.toArray
-    UnsafeMemory.unsafe.copyMemory(ba, srcOffset, ia, destOffset, len * 1)
-    (ia, nextPos + len * 1)
-  }
+  def decodeByteArrayFrom(pos: Int): (Array[Byte], Int) =
+    ???
 
-  def decodeShortArrayFrom(pos: Int): (Array[Short], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Short](len)
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.shortArrayOffset
-    val newbuf = buf.slice(nextPos, nextPos + len * 2)
-    val ba: Array[Byte] = newbuf.toArray
-    UnsafeMemory.unsafe.copyMemory(ba, srcOffset, ia, destOffset, len * 2)
-    (ia, nextPos + len * 2)
-  }
+  def decodeShortArrayFrom(pos: Int): (Array[Short], Int) =
+    ???
 
-  def decodeCharArrayFrom(pos: Int): (Array[Char], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Char](len)
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.charArrayOffset
-    val newbuf = buf.slice(nextPos, nextPos + len * 2)
-    val ba: Array[Byte] = newbuf.toArray
-    UnsafeMemory.unsafe.copyMemory(ba, srcOffset, ia, destOffset, len * 2)
-    (ia, nextPos + len * 2)
-  }
+  def decodeCharArrayFrom(pos: Int): (Array[Char], Int) =
+    ???
 
-  def decodeIntArrayFrom(pos: Int): (Array[Int], Int) = {
-    // buf: ArrayBuffer[Byte]
-    // 1. read length
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
+  def decodeIntArrayFrom(pos: Int): (Array[Int], Int) =
+    ???
 
-    // 2. allocate Array[Int] TODO: use Unsafe
-    val ia = Array.ofDim[Int](len)
+  def decodeLongArrayFrom(pos: Int): (Array[Long], Int) =
+    ???
 
-    // 3. the copy
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.intArrayOffset
-    // read the required num of bytes from `buf`
-    val newbuf = buf.slice(nextPos, nextPos + len * 4)
-    val ba: Array[Byte] = newbuf.toArray
-    UnsafeMemory.unsafe.copyMemory(ba, srcOffset, ia, destOffset, len * 4)
+  def decodeBooleanArrayFrom(pos: Int): (Array[Boolean], Int) =
+    ???
 
-    (ia, nextPos + len * 4)
-  }
+  def decodeFloatArrayFrom(pos: Int): (Array[Float], Int) =
+    ???
 
-  def decodeLongArrayFrom(pos: Int): (Array[Long], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Long](len)
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.longArrayOffset
-    val newbuf = buf.slice(nextPos, nextPos + len * 8)
-    val ba: Array[Byte] = newbuf.toArray
-    UnsafeMemory.unsafe.copyMemory(ba, srcOffset, ia, destOffset, len * 8)
-    (ia, nextPos + len * 8)
-  }
-
-  def decodeBooleanArrayFrom(pos: Int): (Array[Boolean], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Boolean](len)
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.booleanArrayOffset
-    val newbuf = buf.slice(nextPos, nextPos + len * 1)
-    val ba: Array[Byte] = newbuf.toArray
-    UnsafeMemory.unsafe.copyMemory(ba, srcOffset, ia, destOffset, len * 1)
-    (ia, nextPos + len * 1)
-  }
-
-  def decodeFloatArrayFrom(pos: Int): (Array[Float], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Float](len)
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.floatArrayOffset
-    val newbuf = buf.slice(nextPos, nextPos + len * 4)
-    val ba: Array[Byte] = newbuf.toArray
-    UnsafeMemory.unsafe.copyMemory(ba, srcOffset, ia, destOffset, len * 4)
-    (ia, nextPos + len * 4)
-  }
-
-  def decodeDoubleArrayFrom(pos: Int): (Array[Double], Int) = {
-    val len = decodeIntFrom(pos)
-    val nextPos = pos+4
-    val ia = Array.ofDim[Double](len)
-    val srcOffset = UnsafeMemory.byteArrayOffset
-    val destOffset = UnsafeMemory.doubleArrayOffset
-    val newbuf = buf.slice(nextPos, nextPos + len * 8)
-    val ba: Array[Byte] = newbuf.toArray
-    UnsafeMemory.unsafe.copyMemory(ba, srcOffset, ia, destOffset, len * 8)
-    (ia, nextPos + len * 8)
-  }
+  def decodeDoubleArrayFrom(pos: Int): (Array[Double], Int) =
+    ???
 
   def toArray: Array[Byte] =
     buf.toArray

--- a/core/src/main/scala/pickling/binary/Util.scala
+++ b/core/src/main/scala/pickling/binary/Util.scala
@@ -6,9 +6,9 @@ package binary {
 
   object Util {
 
-    def copy(target: Array[Byte], pos: Int, arr: Array[Byte]): Unit = {
+    def copy(target: Array[Byte], i: Int, arr: Array[Byte]): Unit = {
       // def copy(src: Object, srcPos: Int, dest: Object, destPos: Int, length: Int)
-      Array.copy(arr, 0, target, pos, arr.length)
+      Array.copy(arr, 0, target, i, arr.length)
     }
 
     /** Returns decoded Short plus next "readable" position in target array.
@@ -195,10 +195,10 @@ package binary {
     def encodeStringTo(arr: Array[Byte], i: Int, value: String): Int = {
       val bytes = value.getBytes("UTF-8")
       // encode length
-      val next = encodeIntTo(arr, i, bytes.length)
+      encodeIntTo(arr, i, bytes.length)
       // encode bytes of string at `next` position
-      Util.copy(arr, next, bytes)
-      next + bytes.length
+      Util.copy(arr, i+4, bytes)
+      i + 4 + bytes.length
     }
 
     def fastencodeStringTo(arr: Array[Byte], i: Int, value: String): Int = {
@@ -218,7 +218,152 @@ package binary {
       buf ++= bytes
       i + 4 + bytes.length
     }
+    
+    def encodeByteArrayTo(arr: Array[Byte], i: Int, value: Array[Byte]): Int = {
+      encodeIntTo(arr, i, value.length)
+      val srcOffset = UnsafeMemory.byteArrayOffset
+      val destOffset = UnsafeMemory.byteArrayOffset
+      UnsafeMemory.unsafe.copyMemory(value, srcOffset, arr, destOffset + i + 4, value.length * 1)
+      i + 4 + value.length * 1
+    }
+    
+    def encodeShortArrayTo(arr: Array[Byte], i: Int, value: Array[Short]): Int = {
+      encodeIntTo(arr, i, value.length)
+      val srcOffset = UnsafeMemory.shortArrayOffset
+      val destOffset = UnsafeMemory.byteArrayOffset
+      UnsafeMemory.unsafe.copyMemory(value, srcOffset, arr, destOffset + i + 4, value.length * 2)
+      i + 4 + value.length * 2
+    }
+    
+    def encodeCharArrayTo(arr: Array[Byte], i: Int, value: Array[Char]): Int = {
+      encodeIntTo(arr, i, value.length)
+      val srcOffset = UnsafeMemory.charArrayOffset
+      val destOffset = UnsafeMemory.byteArrayOffset
+      UnsafeMemory.unsafe.copyMemory(value, srcOffset, arr, destOffset + i + 4, value.length * 2)
+      i + 4 + value.length * 2
+    }
+    
+    def encodeIntArrayTo(arr: Array[Byte], i: Int, value: Array[Int]): Int = {
+      encodeIntTo(arr, i, value.length)
+      val srcOffset = UnsafeMemory.intArrayOffset
+      val destOffset = UnsafeMemory.byteArrayOffset
+      UnsafeMemory.unsafe.copyMemory(value, srcOffset, arr, destOffset + i + 4, value.length * 4)
+      i + 4 + value.length * 4
+    }
+    
+    def encodeLongArrayTo(arr: Array[Byte], i: Int, value: Array[Long]): Int = {
+      encodeIntTo(arr, i, value.length)
+      val srcOffset = UnsafeMemory.longArrayOffset
+      val destOffset = UnsafeMemory.byteArrayOffset
+      UnsafeMemory.unsafe.copyMemory(value, srcOffset, arr, destOffset + i + 4, value.length * 8)
+      i + 4 + value.length * 8
+    }
+    
+    def encodeBooleanArrayTo(arr: Array[Byte], i: Int, value: Array[Boolean]): Int = {
+      encodeIntTo(arr, i, value.length)
+      val srcOffset = UnsafeMemory.booleanArrayOffset
+      val destOffset = UnsafeMemory.byteArrayOffset
+      UnsafeMemory.unsafe.copyMemory(value, srcOffset, arr, destOffset + i + 4, value.length * 1)
+      i + 4 + value.length * 1
+    }
+    
+    def encodeFloatArrayTo(arr: Array[Byte], i: Int, value: Array[Float]): Int = {
+      encodeIntTo(arr, i, value.length)
+      val srcOffset = UnsafeMemory.floatArrayOffset
+      val destOffset = UnsafeMemory.byteArrayOffset
+      UnsafeMemory.unsafe.copyMemory(value, srcOffset, arr, destOffset + i + 4, value.length * 4)
+      i + 4 + value.length * 4
+    }
+    
+    def encodeDoubleArrayTo(arr: Array[Byte], i: Int, value: Array[Double]): Int = {
+      encodeIntTo(arr, i, value.length)
+      val srcOffset = UnsafeMemory.doubleArrayOffset
+      val destOffset = UnsafeMemory.byteArrayOffset
+      UnsafeMemory.unsafe.copyMemory(value, srcOffset, arr, destOffset + i + 4, value.length * 8)
+      i + 4 + value.length * 8
+    }
+    
+    def decodeByteArrayFrom(arr: Array[Byte], i: Int): (Array[Byte], Int) = {
+      val len = decodeIntFrom(arr, i)
+      val nextPos = i+4
+      val ia = Array.ofDim[Byte](len)
+      val srcOffset = UnsafeMemory.byteArrayOffset
+      val destOffset = UnsafeMemory.intArrayOffset
+      UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 1)
+      (ia, nextPos + len * 1)
+    }
+    
+    def decodeShortArrayFrom(arr: Array[Byte], i: Int): (Array[Short], Int) = {
+      val len = decodeIntFrom(arr, i)
+      val nextPos = i+4
+      val ia = Array.ofDim[Short](len)
+      val srcOffset = UnsafeMemory.shortArrayOffset
+      val destOffset = UnsafeMemory.intArrayOffset
+      UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 2)
+      (ia, nextPos + len * 2)
+    }
 
+    def decodeCharArrayFrom(arr: Array[Byte], i: Int): (Array[Char], Int) = {
+      val len = decodeIntFrom(arr, i)
+      val nextPos = i+4
+      val ia = Array.ofDim[Char](len)
+      val srcOffset = UnsafeMemory.charArrayOffset
+      val destOffset = UnsafeMemory.intArrayOffset
+      UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 2)
+      (ia, nextPos + len * 2)
+    }
+
+    def decodeIntArrayFrom(arr: Array[Byte], i: Int): (Array[Int], Int) = {
+
+      val len = decodeIntFrom(arr, i)
+      val nextPos = i+4
+      val ia = Array.ofDim[Int](len)
+      val srcOffset = UnsafeMemory.byteArrayOffset
+      val destOffset = UnsafeMemory.intArrayOffset
+      UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 4)
+
+      (ia, nextPos + len * 4)
+    }
+
+    def decodeLongArrayFrom(arr: Array[Byte], i: Int): (Array[Long], Int) = {
+      val len = decodeIntFrom(arr, i)
+      val nextPos = i+4
+      val ia = Array.ofDim[Long](len)
+      val srcOffset = UnsafeMemory.longArrayOffset
+      val destOffset = UnsafeMemory.intArrayOffset
+      UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 8)
+      (ia, nextPos + len * 8)
+    }
+
+    def decodeBooleanArrayFrom(arr: Array[Byte], i: Int): (Array[Boolean], Int) = {
+      val len = decodeIntFrom(arr, i)
+      val nextPos = i+4
+      val ia = Array.ofDim[Boolean](len)
+      val srcOffset = UnsafeMemory.booleanArrayOffset
+      val destOffset = UnsafeMemory.intArrayOffset
+      UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 1)
+      (ia, nextPos + len * 1)
+    }
+
+    def decodeFloatArrayFrom(arr: Array[Byte], i: Int): (Array[Float], Int) = {
+      val len = decodeIntFrom(arr, i)
+      val nextPos = i+4
+      val ia = Array.ofDim[Float](len)
+      val srcOffset = UnsafeMemory.floatArrayOffset
+      val destOffset = UnsafeMemory.intArrayOffset
+      UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 4)
+      (ia, nextPos + len * 4)
+    }
+
+    def decodeDoubleArrayFrom(arr: Array[Byte], i: Int): (Array[Double], Int) = {
+      val len = decodeIntFrom(arr, i)
+      val nextPos = i+4
+      val ia = Array.ofDim[Double](len)
+      val srcOffset = UnsafeMemory.doubleArrayOffset
+      val destOffset = UnsafeMemory.intArrayOffset
+      UnsafeMemory.unsafe.copyMemory(arr, srcOffset + nextPos, ia, destOffset, len * 8)
+      (ia, nextPos + len * 8)
+    }
   }
 
   object UnsafeMemory {
@@ -236,12 +381,12 @@ package binary {
     private[binary] val floatArrayOffset: Long = unsafe.arrayBaseOffset(classOf[Array[Float]])
     private[binary] val doubleArrayOffset: Long = unsafe.arrayBaseOffset(classOf[Array[Double]])
 
-    def putInt(buffer: Array[Byte], pos: Int, value: Int): Unit = {
-      unsafe.putInt(buffer, byteArrayOffset + pos, value)
+    def putInt(buffer: Array[Byte], i: Int, value: Int): Unit = {
+      unsafe.putInt(buffer, byteArrayOffset + i, value)
     }
 
-    def getInt(buffer: Array[Byte], pos: Int): Int = {
-      unsafe.getInt(buffer, byteArrayOffset + pos)
+    def getInt(buffer: Array[Byte], i: Int): Int = {
+      unsafe.getInt(buffer, byteArrayOffset + i)
     }
   }
 


### PR DESCRIPTION
Fix for issue #66

Changelog:
- Changed encodeXXAtEnd to encodeXXTo, as it's what's actually done.
- Moved all accesses to UnsafeMemory.Copy to binary.Util.
- Removed the decoding methods from ByteArrayBuffer as they are never used.
- Uniformized the code to prepare for the removal of EncodedOutput.
