### PR TITLE
Fix #75 - Runtime exception when unpickling Array of Tuple

### DIFF
--- a/core/src/main/scala/pickling/internal/AppliedType.scala
+++ b/core/src/main/scala/pickling/internal/AppliedType.scala
@@ -1,0 +1,41 @@
+package scala.pickling.internal
+
+object AppliedType {
+  // the delimiters in an applied type
+  private val delims = List(',', '[', ']')
+
+  /* Parse an applied type.
+   *
+   * @param  s the string that is parsed
+   * @return   a pair with the parsed applied type and the remaining string.
+   */
+  def parse(s: String): (AppliedType, String) = {
+    // shape of `s`: fqn[at_1, ..., at_n]
+    val (typename, rem) = s.span(!delims.contains(_))
+
+    if (rem.isEmpty || rem.startsWith(",") || rem.startsWith("]")) {
+      (AppliedType(typename, List()), rem)
+    } else { // parse type arguments
+      var typeArgs  = List[AppliedType]()
+      var remaining = rem
+
+      while (remaining.startsWith("[") || remaining.startsWith(",")) {
+        remaining = remaining.substring(1)
+        val (nextAppliedType, rem) = parse(remaining)
+        typeArgs = typeArgs :+ nextAppliedType
+        remaining = rem
+      }
+
+      (AppliedType(typename, typeArgs), if (remaining.startsWith("]")) remaining.substring(1) else remaining)
+    }
+  }
+
+}
+
+/**
+ * Simple representation of an applied type. Used for reading pickled types.
+ */
+case class AppliedType(typename: String, typeargs: List[AppliedType]) {
+  override def toString =
+    typename + (if (typeargs.isEmpty) "" else typeargs.mkString("[", ",", "]"))
+}

--- a/core/src/test/scala/pickling/pickling-spec.scala
+++ b/core/src/test/scala/pickling/pickling-spec.scala
@@ -253,6 +253,18 @@ object PicklingJsonSpec extends Properties("pickling-json") {
     readArr.sameElements(ia)
   })
 
+  property("Array[(Int, Double)]") = forAll((ia: Array[(Int, Double)]) => {
+    val pickle: JSONPickle = ia.pickle
+    val readArr = pickle.unpickle[Array[(Int, Double)]]
+    readArr.sameElements(ia)
+  })
+
+  property("Array[(String, Int)]") = forAll((ia: Array[(String, Int)]) => {
+    val pickle: JSONPickle = ia.pickle
+    val readArr = pickle.unpickle[Array[(String, Int)]]
+    readArr.sameElements(ia)
+  })
+
   property("BigDecimal") = Prop forAll { (x: Double) =>
     val bd = new BigDecimal(x)
     val pickle: JSONPickle = bd.pickle
@@ -474,6 +486,18 @@ object PicklingBinarySpec extends Properties("pickling-binary") {
   property("Array[Double]") = forAll((ia: Array[Double]) => {
     val pickle: BinaryPickle = ia.pickle
     val readArr = pickle.unpickle[Array[Double]]
+    readArr.sameElements(ia)
+  })
+
+  property("Array[(Int, Double)]") = forAll((ia: Array[(Int, Double)]) => {
+    val pickle: BinaryPickle = ia.pickle
+    val readArr = pickle.unpickle[Array[(Int, Double)]]
+    readArr.sameElements(ia)
+  })
+
+  property("Array[(String, Int)]") = forAll((ia: Array[(String, Int)]) => {
+    val pickle: BinaryPickle = ia.pickle
+    val readArr = pickle.unpickle[Array[(String, Int)]]
     readArr.sameElements(ia)
   })
 


### PR DESCRIPTION
- Nested applied types are now read correctly from pickles
- Adds a helper class and its companion object in the `internal` package
- Adds two ScalaCheck tests
