### PR TITLE
Make DPickler a pure abstract trait

### DIFF
--- a/core/src/main/scala/pickling/Compat.scala
+++ b/core/src/main/scala/pickling/Compat.scala
@@ -78,12 +78,6 @@ object Compat {
     c.Expr[DPickler[T]](bundle.dpicklerImpl[T](format.tree))
   }
 
-  def PickleMacros_dpicklerPickle[T: c.WeakTypeTag](c: Context)(picklee: c.Expr[T], builder: c.Expr[PBuilder]): c.Expr[Unit] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with PickleMacros
-    c.Expr[Unit](bundle.dpicklerPickle[T](picklee.tree, builder.tree))
-  }
-
   def CurrentMirrorMacro_impl(c: Context): c.Expr[ru.Mirror] = {
     val c0: c.type = c
     val bundle = new { val c: c0.type = c0 } with CurrentMirrorMacro

--- a/core/src/main/scala/pickling/Macros.scala
+++ b/core/src/main/scala/pickling/Macros.scala
@@ -164,12 +164,18 @@ trait PicklerMacros extends Macro {
   def dpicklerImpl[T: c.WeakTypeTag](format: c.Tree): c.Tree = {
     val tpe = weakTypeOf[T]
     val picklerName = c.fresh((syntheticBaseName(tpe) + "DPickler"): TermName)
+
+    val c0: c.type = c
+    val bundle = new { val c: c0.type = c0 } with PickleMacros
+    val dpicklerPickleImpl = bundle.dpicklerPickle[T](q"builder")
+
     q"""
       implicit object $picklerName extends scala.pickling.DPickler[$tpe] {
         import scala.pickling._
         import scala.pickling.internal._
         import scala.pickling.`package`.PickleOps
         val format = implicitly[${format.tpe}]
+        def pickle(picklee: $tpe, builder: PBuilder): Unit = $dpicklerPickleImpl
       }
       $picklerName
     """
@@ -414,16 +420,15 @@ trait PickleMacros extends Macro {
   /* This macro first dispatches to the right SPickler, using the same dispatch logic
    * as in `pickleInto`, and then simply invokes `pickle` on it.
    */
-  def dpicklerPickle[T: c.WeakTypeTag](picklee: c.Tree, builder: c.Tree): c.Tree = {
+  def dpicklerPickle[T: c.WeakTypeTag](builder: c.Tree): c.Tree = {
     val tpe = weakTypeOf[T].widen
     val sym = tpe.typeSymbol.asClass
     val dispatchLogic = genDispatchLogic(tpe, builder)
     q"""
       import scala.pickling._
       import scala.pickling.internal._
-      val picklee = $picklee
       val pickler = $dispatchLogic
-      pickler.asInstanceOf[SPickler[$tpe]].pickle($picklee, $builder)
+      pickler.asInstanceOf[SPickler[$tpe]].pickle(picklee, $builder)
     """
   }
 }

--- a/core/src/main/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/pickling/Pickler.scala
@@ -32,7 +32,7 @@ trait SPickler[T] {
 @implicitNotFound(msg = "Cannot generate a DPickler for ${T}. Recompile with -Xlog-implicits for details")
 trait DPickler[T] {
   val format: PickleFormat
-  def pickle(picklee: T, builder: PBuilder): Unit = macro Compat.PickleMacros_dpicklerPickle[T]
+  def pickle(picklee: T, builder: PBuilder): Unit
 }
 
 object DPickler {


### PR DESCRIPTION
- Removes macro invocation in DPickler
- This is part of an effort to separate the pickling API from
  the macro implementation
