### PR TITLE
Make Scala version used for build configurable via system property

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@ import java.net.URL
 
 object BuildSettings {
   val buildVersion = "0.9.0-SNAPSHOT"
-  val buildScalaVersion = "2.11.0"
+  val buildScalaVersion = System.getProperty("scala.version", "2.11.0")
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
     version := buildVersion,


### PR DESCRIPTION
- Enable configuring the Scala version used for the build using
  the 'scala.version' system property.
- The default Scala version is 2.11.0 if the system property is not set.
