### PR TITLE
Enable pickling of anonymous functions

### DIFF
--- a/core/src/main/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/pickling/Pickler.scala
@@ -66,7 +66,7 @@ trait Unpickler[T] {
 trait GenUnpicklers {
   implicit def genUnpickler[T](implicit format: PickleFormat): Unpickler[T] = macro Compat.UnpicklerMacros_impl[T]
   def genUnpickler(mirror: Mirror, tag: FastTypeTag[_])(implicit format: PickleFormat, share: refs.Share): Unpickler[_] = {
-    // println(s"generating runtime unpickler for ${tag.tpe}") // NOTE: needs to be an explicit println, so that we don't occasionally fallback to runtime in static cases
+    // println(s"generating runtime unpickler for ${tag.key}") // NOTE: needs to be an explicit println, so that we don't occasionally fallback to runtime in static cases
     //val runtime = new CompiledUnpicklerRuntime(mirror, tag.tpe)
     val runtime = new InterpretedUnpicklerRuntime(mirror, tag)
     runtime.genUnpickler

--- a/core/src/main/scala/pickling/binary/BinaryPickleFormat.scala
+++ b/core/src/main/scala/pickling/binary/BinaryPickleFormat.scala
@@ -64,8 +64,13 @@ package binary {
         Util.encodeByte(output, REF_TAG)
         Util.encodeInt(output, hints.oid)
       } else {
-        if (!hints.isElidedType)
-          Util.encodeString(output, hints.tag.key)
+        if (!hints.isElidedType) {
+          // quickly decide whether we should use picklee.getClass instead
+          val ts =
+            if (hints.tag.key.contains("anonfun$")) picklee.getClass.getName
+            else hints.tag.key
+          Util.encodeString(output, ts)
+        }
 
         // NOTE: it looks like we don't have to write object ids at all
         // traversals employed by pickling and unpickling are exactly the same

--- a/core/src/main/scala/pickling/json/JSONPickleFormat.scala
+++ b/core/src/main/scala/pickling/json/JSONPickleFormat.scala
@@ -117,7 +117,13 @@ package json {
           }
         } else {
           appendLine("{")
-          if (!hints.isElidedType) append("\"tpe\": \"" + typeToString(hints.tag.tpe) + "\"")
+          if (!hints.isElidedType) {
+            // quickly decide whether we should use picklee.getClass instead
+            val ts =
+              if (hints.tag.key.contains("anonfun$")) picklee.getClass.getName
+              else typeToString(hints.tag.tpe)
+            append("\"tpe\": \"" + ts + "\"")
+          }
         }
       }
       this

--- a/core/src/test/scala/pickling/run/anonfun-binary.scala
+++ b/core/src/test/scala/pickling/run/anonfun-binary.scala
@@ -1,0 +1,15 @@
+package scala.pickling.run.anonfun
+
+import org.scalatest.FunSuite
+import scala.pickling._
+import binary._
+
+class AnonfunBinaryTest extends FunSuite {
+  val fun: Int => Int = (x: Int) => x + 1
+
+  test("main") {
+    val p = fun.pickle
+    val up = p.unpickle[Int => Int]
+    assert(up(5) === 6)
+  }
+}

--- a/core/src/test/scala/pickling/run/anonfun-json.scala
+++ b/core/src/test/scala/pickling/run/anonfun-json.scala
@@ -1,0 +1,15 @@
+package scala.pickling.run.anonfun
+
+import org.scalatest.FunSuite
+import scala.pickling._
+import json._
+
+class AnonfunJsonTest extends FunSuite {
+  val fun: Int => Int = (x: Int) => x + 1
+
+  test("main") {
+    val p = fun.pickle
+    val up = p.unpickle[Int => Int]
+    assert(up(5) === 6)
+  }
+}


### PR DESCRIPTION
Note that captured environments of anonymous functions are not
pickled. In case an anonymous function with an environment
is unpickled, its environment remains uninitialized.

Integration with spores is intended to support in addition also
pickling of arbitrary complex environments.
