### PR TITLE
Add global reflection lock

### DIFF
--- a/core/src/main/scala/pickling/Macros.scala
+++ b/core/src/main/scala/pickling/Macros.scala
@@ -500,8 +500,11 @@ trait PickleMacros extends Macro {
       import scala.pickling._
       import scala.pickling.internal._
       val picklee = $pickleeArg
+      GRL.acquire()
       val pickler = $dispatchLogic
-      pickler.asInstanceOf[SPickler[$tpe]].pickle(picklee, $builder)
+      val res = pickler.asInstanceOf[SPickler[$tpe]].pickle(picklee, $builder)
+      GRL.release()
+      res
     """
   }
 
@@ -608,6 +611,7 @@ trait UnpickleMacros extends Macro {
 
     q"""
       val reader = $readerArg
+      GRL.acquire()
       reader.hintTag(implicitly[scala.pickling.FastTypeTag[$tpe]])
       $staticHint
       val typeString = reader.beginEntryNoTag()
@@ -615,6 +619,7 @@ trait UnpickleMacros extends Macro {
       val result = unpickler.unpickle({ scala.pickling.FastTypeTag(typeString) }, reader)
       reader.endEntry()
       $unpickleeCleanup
+      GRL.release()
       result.asInstanceOf[$tpe]
     """
   }

--- a/core/src/main/scala/pickling/Macros.scala
+++ b/core/src/main/scala/pickling/Macros.scala
@@ -500,10 +500,10 @@ trait PickleMacros extends Macro {
       import scala.pickling._
       import scala.pickling.internal._
       val picklee = $pickleeArg
-      GRL.acquire()
+      GRL.lock()
       val pickler = $dispatchLogic
       val res = pickler.asInstanceOf[SPickler[$tpe]].pickle(picklee, $builder)
-      GRL.release()
+      GRL.unlock()
       res
     """
   }
@@ -611,7 +611,7 @@ trait UnpickleMacros extends Macro {
 
     q"""
       val reader = $readerArg
-      GRL.acquire()
+      GRL.lock()
       reader.hintTag(implicitly[scala.pickling.FastTypeTag[$tpe]])
       $staticHint
       val typeString = reader.beginEntryNoTag()
@@ -619,7 +619,7 @@ trait UnpickleMacros extends Macro {
       val result = unpickler.unpickle({ scala.pickling.FastTypeTag(typeString) }, reader)
       reader.endEntry()
       $unpickleeCleanup
-      GRL.release()
+      GRL.unlock()
       result.asInstanceOf[$tpe]
     """
   }

--- a/core/src/main/scala/pickling/internal/package.scala
+++ b/core/src/main/scala/pickling/internal/package.scala
@@ -11,6 +11,15 @@ package object internal {
   import ru._
   import compat._
 
+  /* Global reflection lock.
+   * It is used to avoid data races that typically lead to runtime exceptions
+   * when using (Scala) runtime reflection on Scala 2.10.x.
+   *
+   * Note: visibility must be public, so that the lock can be accessed from
+   *       macro-generated code.
+   */
+  val GRL = new scala.concurrent.Lock
+
   // TOGGLE DEBUGGING
   private val debugEnabled: Boolean = System.getProperty("pickling.debug", "false").toBoolean
   private[pickling] def debug(output: => String) = if (debugEnabled) println(output)

--- a/core/src/main/scala/pickling/internal/package.scala
+++ b/core/src/main/scala/pickling/internal/package.scala
@@ -18,7 +18,7 @@ package object internal {
    * Note: visibility must be public, so that the lock can be accessed from
    *       macro-generated code.
    */
-  val GRL = new scala.concurrent.Lock
+  val GRL = new java.util.concurrent.locks.ReentrantLock
 
   // TOGGLE DEBUGGING
   private val debugEnabled: Boolean = System.getProperty("pickling.debug", "false").toBoolean


### PR DESCRIPTION
This avoids data races that typically lead to runtime exceptions
when running on Scala 2.10.x.
