### PR TITLE
Replace unpickle macro in trait Pickle with extension method

### DIFF
--- a/core/src/main/scala/pickling/Compat.scala
+++ b/core/src/main/scala/pickling/Compat.scala
@@ -49,7 +49,7 @@ object Compat {
     val tpe = c.universe.weakTypeOf[T]
     // abort if someone forgets to pass a type parameter to the unpickle method
     val isNothing = tpe =:= definitions.NothingTpe
-    val unpickleSym = c.mirror.staticClass("scala.pickling.Pickle").asType.toType.member(newTermName("unpickle"))
+    val unpickleSym = c.mirror.staticClass("scala.pickling.UnpickleOps").asType.toType.member(newTermName("unpickle"))
     val typeArgMissing = tpe match {
       case t: TypeRef => t.typeSymbol.owner == unpickleSym || isNothing
       case _ => false

--- a/core/src/main/scala/pickling/PickleFormat.scala
+++ b/core/src/main/scala/pickling/PickleFormat.scala
@@ -1,20 +1,18 @@
 package scala.pickling
 
-import scala.language.experimental.macros
-
 import scala.reflect.runtime.universe.Mirror
+
 
 trait Pickle {
   type ValueType
-  val value: ValueType
 
-  type PickleFormatType <: PickleFormat
-  def unpickle[T] = macro Compat.UnpickleMacros_pickleUnpickle[T]
+  val value: ValueType
 }
 
 trait PickleFormat {
   type PickleType <: Pickle
   type OutputType
+
   def createBuilder(): PBuilder
   def createBuilder(out: OutputType): PBuilder
   def createReader(pickle: PickleType, mirror: Mirror): PReader

--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -2,8 +2,6 @@ package scala
 
 import scala.language.experimental.macros
 
-import scala.reflect.runtime.{universe => ru}
-import ru._
 
 package object pickling {
 
@@ -11,6 +9,10 @@ package object pickling {
     def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
     def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]
     def pickleTo(output: Output[_])(implicit format: PickleFormat): Unit = macro Compat.PickleMacros_pickleTo[T]
+  }
+
+  implicit class UnpickleOps(pickle: Pickle) {
+    def unpickle[T]: T = macro Compat.UnpickleMacros_pickleUnpickle[T]
   }
 
 }


### PR DESCRIPTION
- Removes `PickleFormatType` type member from trait `Pickle`.
- Makes unpickling API symmetric with pickling API.
- Removes unused method `Macro#pickleFormatType` and method `Macro#innerType`.
- Removes unused code in object `Tools`.
