### PR TITLE
Reject refined types by generation macro

### DIFF
--- a/core/src/test/scala/pickling/neg/refined-type-fail.scala
+++ b/core/src/test/scala/pickling/neg/refined-type-fail.scala
@@ -1,0 +1,22 @@
+package scala.pickling.refinedtypefail
+
+import scala.pickling._
+import NegativeCompilation._
+import org.scalatest.FunSuite
+
+class RefinedTypeFailTest extends FunSuite {
+  test("main") {
+    expectError("could not find implicit pickler for refined type") {
+      """import _root_.scala.pickling._
+        |import _root_.scala.pickling.json._
+        |
+        |class C { type Cap }
+        |
+        |object Test {
+        |  type T = C { type Cap = Int }
+        |  val x: T = null
+        |  val p = x.pickle
+        |}""".stripMargin
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,8 +1,5 @@
 import sbt._
 import Keys._
-import scala.util.Properties
-import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
-import scala.xml.transform._
 import java.net.URL
 
 object BuildSettings {


### PR DESCRIPTION
The generation macro statically attempts to infer a matching
implicit pickler, and reports an error if unsuccessful.

Pickling refined types requires custom implicit picklers.
