### PR TITLE
Update to latest minor releases of dependencies

### DIFF
--- a/core/src/test/scala/pickling/NegativeCompilation.scala
+++ b/core/src/test/scala/pickling/NegativeCompilation.scala
@@ -68,7 +68,7 @@ object NegativeCompilation {
 
   def quasiquotesJar: String = {
     val dir = System.getProperty("user.dir")
-    if (scalaBinaryVersion == "2.10") s":$dir/quasiquotes_2.10-2.0.0.jar"
+    if (scalaBinaryVersion == "2.10") s":$dir/quasiquotes_2.10-2.0.1.jar"
     else ""
   }
 

--- a/core/src/test/scala/pickling/neg/refined-type-fail.scala
+++ b/core/src/test/scala/pickling/neg/refined-type-fail.scala
@@ -12,11 +12,8 @@ class RefinedTypeFailTest extends FunSuite {
         |
         |class C { type Cap }
         |
-        |object Test {
-        |  type T = C { type Cap = Int }
-        |  val x: T = null
-        |  val p = x.pickle
-        |}""".stripMargin
+        |val x: C { type Cap = Int } = new C { type Cap = Int }
+        |val p = x.pickle""".stripMargin
     }
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -4,7 +4,7 @@ import java.net.URL
 
 object BuildSettings {
   val buildVersion = "0.9.1-SNAPSHOT"
-  val buildScalaVersion = System.getProperty("scala.version", "2.11.2")
+  val buildScalaVersion = System.getProperty("scala.version", "2.11.4")
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
     version := buildVersion,
@@ -70,19 +70,19 @@ object MyBuild extends Build {
       scalacOptions ++= Seq("-optimise"),
       libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _),
       libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-compiler" % _), // for ToolBox
-      libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.3" % "test",
-      libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.11.3" % "test",
+      libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.7" % "test",
+      libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.11.6" % "test",
       libraryDependencies := {
         CrossVersion.partialVersion(scalaVersion.value) match {
           // if scala 2.11+ is used, quasiquotes are merged into scala-reflect
           case Some((2, scalaMajor)) if scalaMajor >= 11 =>
             libraryDependencies.value ++ Seq(
-              "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1")
+              "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2")
           // in Scala 2.10, quasiquotes are provided by macro-paradise
           case Some((2, 10)) =>
             libraryDependencies.value ++ Seq(
-              compilerPlugin("org.scalamacros" % "paradise" % "2.0.0" cross CrossVersion.full),
-              "org.scalamacros" %% "quasiquotes" % "2.0.0")
+              compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full),
+              "org.scalamacros" %% "quasiquotes" % "2.0.1")
         }
       },
       conflictWarning in ThisBuild := ConflictWarning.disable,
@@ -176,7 +176,7 @@ object MyBuild extends Build {
     settings = buildSettings ++ Seq(
       sourceDirectory in Compile <<= baseDirectory(root => root),
       sourceDirectory in Test <<= baseDirectory(root => root),
-      libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.3",
+      libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.7",
       parallelExecution in Test := false,
       // scalacOptions ++= Seq()
       scalacOptions ++= Seq("-Xlog-implicits")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.6


### PR DESCRIPTION
This is an update to the latest minor releases of all dependencies.

The new versions are:
sbt: 0.13.6
scalatest: 2.1.7
scalacheck: 1.11.6

For Scala 2.11 only:
scala: 2.11.4
scala-parser-combinators: 1.0.2

For Scala 2.10 only:
paradise: 2.0.1
quasiquotes: 2.0.1
