### PR TITLE
Require implicit FastTypeTags at interface methods

### DIFF
--- a/core/src/main/scala/pickling/Compat.scala
+++ b/core/src/main/scala/pickling/Compat.scala
@@ -25,25 +25,25 @@ object Compat {
     c.Expr[Unpickler[T] with Generated](bundle.impl[T])
   }
 
-  def PickleMacros_pickle[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[format.value.PickleType] = {
+  def PickleMacros_pickle[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat], tag: c.Expr[FastTypeTag[T]]): c.Expr[format.value.PickleType] = {
     val c0: c.type = c
     val bundle = new { val c: c0.type = c0 } with PickleMacros
     c.Expr[format.value.PickleType](bundle.pickle[T](format.tree))
   }
 
-  def PickleMacros_pickleInto[T: c.WeakTypeTag](c: Context)(builder: c.Expr[PBuilder]): c.Expr[Unit] = {
+  def PickleMacros_pickleInto[T: c.WeakTypeTag](c: Context)(builder: c.Expr[PBuilder])(tag: c.Expr[FastTypeTag[T]]): c.Expr[Unit] = {
     val c0: c.type = c
     val bundle = new { val c: c0.type = c0 } with PickleMacros
     c.Expr[Unit](bundle.pickleInto[T](builder.tree))
   }
 
-  def PickleMacros_pickleTo[T: c.WeakTypeTag](c: Context)(output: c.Expr[Output[_]])(format: c.Expr[PickleFormat]): c.Expr[Unit] = {
+  def PickleMacros_pickleTo[T: c.WeakTypeTag](c: Context)(output: c.Expr[Output[_]])(format: c.Expr[PickleFormat], tag: c.Expr[FastTypeTag[T]]): c.Expr[Unit] = {
     val c0: c.type = c
     val bundle = new { val c: c0.type = c0 } with PickleMacros
     c.Expr[Unit](bundle.pickleTo[T](output.tree)(format.tree))
   }
 
-  def UnpickleMacros_pickleUnpickle[T: c.WeakTypeTag](c: Context): c.Expr[T] = {
+  def UnpickleMacros_pickleUnpickle[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[T] = {
     import c.universe._
     val c0: c.type = c
     val tpe = c.universe.weakTypeOf[T]
@@ -58,6 +58,11 @@ object Compat {
       c.abort(c.enclosingPosition, """cannot unpickle because the (inferred) type argument of unpickle is abstract.
         |Typically, this is caused by omitting an explicit type argument. Always invoke unpickle with a concrete
         |type argument, for example, unpickle[Int]""".stripMargin)
+
+    val tagTree = c.inferImplicitValue(appliedType(typeOf[FastTypeTag[_]].typeConstructor, List(tpe)))
+    if (tagTree == EmptyTree)
+      c.abort(c.enclosingPosition, s"could not find implicit FastTypeTag for type: $tpe")
+
     val bundle = new { val c: c0.type = c0 } with UnpickleMacros
     c.Expr[T](bundle.pickleUnpickle[T])
   }

--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -6,13 +6,13 @@ import scala.language.experimental.macros
 package object pickling {
 
   implicit class PickleOps[T](picklee: T) {
-    def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
-    def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]
-    def pickleTo(output: Output[_])(implicit format: PickleFormat): Unit = macro Compat.PickleMacros_pickleTo[T]
+    def pickle(implicit format: PickleFormat, tag: FastTypeTag[T]): format.PickleType = macro Compat.PickleMacros_pickle[T]
+    def pickleInto(builder: PBuilder)(implicit tag: FastTypeTag[T]): Unit = macro Compat.PickleMacros_pickleInto[T]
+    def pickleTo(output: Output[_])(implicit format: PickleFormat, tag: FastTypeTag[T]): Unit = macro Compat.PickleMacros_pickleTo[T]
   }
 
   implicit class UnpickleOps(val thePickle: Pickle) {
-    def unpickle[T]: T = macro Compat.UnpickleMacros_pickleUnpickle[T]
+    def unpickle[T](implicit format: PickleFormat): T = macro Compat.UnpickleMacros_pickleUnpickle[T]
   }
 
 }


### PR DESCRIPTION
The unpickle macro now also requires an implicit PickleFormat at the invocation site.
