### PR TITLE
Add failing test for exception on unknown discriminator for sealed trait

### DIFF
--- a/core/src/test/scala/pickling/run/sealed-trait.scala
+++ b/core/src/test/scala/pickling/run/sealed-trait.scala
@@ -1,32 +1,40 @@
 package scala.pickling.test
 
 import scala.pickling._
-
+import scala.pickling.static._
+import scala.pickling.json._
 import org.scalatest.FunSuite
 
 
 sealed trait Fruit
-final case class Apple(kind: String) extends Fruit
-final case class Orange(ripeness: String) extends Fruit
+sealed trait RedOrOrangeFruit extends Fruit
+final case class Apple(kind: String) extends RedOrOrangeFruit
+final case class Orange(ripeness: String) extends RedOrOrangeFruit
+final case class Banana(something: Int) extends Fruit
+
+final case class Cucumber(something: Int) // does not extend Fruit
 
 class SealedTraitHierarchyTest extends FunSuite {
 
-  // TODO: this should not need a FastTypeTag
-  def unpickleWrapper[T](s: String)(implicit unpickler1: Unpickler[T], tag: FastTypeTag[T]): T = {
-    import scala.pickling.json._
-    JSONPickle(s).unpickle[T]
-  }
-
-  def pickleWrapper[T](s: T)(implicit pickler1: SPickler[T], tag1: FastTypeTag[T]): String = {
-    import scala.pickling.json._
-    s.pickle.value
-  }
-
   test("main") {
     val apple = Apple("Fuji")
-    val appleString = pickleWrapper[Fruit](apple)
-    assert(unpickleWrapper[Fruit](appleString) == apple)
-    assert(unpickleWrapper[Apple](appleString) == apple)
-  }
+    val appleString = (apple: Fruit).pickle.value
+    assert(JSONPickle(appleString).unpickle[Fruit] == apple)
+    assert(JSONPickle(appleString).unpickle[Apple] == apple)
 
+    val banana = Banana(42)
+    val bananaString = (banana: Fruit).pickle.value
+    assert(JSONPickle(bananaString).unpickle[Fruit] == banana)
+    assert(JSONPickle(bananaString).unpickle[Banana] == banana)
+
+    // if we are only using static (un)picklers, then the Banana
+    // unpickler should not know a thing about Cucumber.
+    try {
+      JSONPickle(bananaString.replace("Banana", "Cucumber")).unpickle[Banana]
+    } catch {
+      case PicklingException(message, cause) =>
+        // TODO assert that we get a helpful message like "we don't know about Cucumbers,
+        // only Apple, Orange, or Banana"
+    }
+  }
 }


### PR DESCRIPTION
The idea here is that for a static unpickler, it should only know
about the sealed trait subtypes available at compile time.

Right now it throws:

java.lang.ClassCastException: scala.pickling.test.Cucumber cannot be cast to scala.pickling.test.Banana

This seems to imply that somehow Cucumber gets unpickled using
runtime information. The failure should have come sooner,
as soon as we didn't recognize the discriminator ?

Here I was trying to debug a problem with compileTimeDispatchees but that
compile time dispatcher code doesn't seem to be used/reached so I may
just be entirely confused. I added helpful-error code to createCompileTimeDispatch for the
"case _" case, that doesn't seem to be used here, and I thought it would be.
The sealed-trait.scala previously used runtime dispatch because of the
issue shown in https://github.com/havocp/pickling/commit/143cb47c3183da5e7963e1c818e8b034feebcc30
but this patch modifies sealed-trait.scala such that it should be using only
static (un)picklers.
