### PR TITLE
Harmonizing automatic and manual picklers, more static-only tests

### DIFF
--- a/core/src/main/scala/pickling/Custom.scala
+++ b/core/src/main/scala/pickling/Custom.scala
@@ -17,11 +17,6 @@ import scala.collection.IndexedSeq
 import scala.collection.LinearSeq
 import mutable.ArrayBuffer
 
-class PicklerUnpicklerNotFound[T] extends SPickler[T] with Unpickler[T] with Generated {
-  def pickle(picklee: T, builder: PBuilder): Unit = ???
-  def unpickle(tag: => FastTypeTag[_], reader: PReader): Any = ???
-  def tag: FastTypeTag[T] = ???
-}
 
 trait LowPriorityPicklersUnpicklers {
 

--- a/core/src/test/scala/pickling/neg/refined-type-fail.scala
+++ b/core/src/test/scala/pickling/neg/refined-type-fail.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSuite
 
 class RefinedTypeFailTest extends FunSuite {
   test("main") {
-    expectError("could not find implicit pickler for refined type") {
+    expectError("Cannot generate") {
       """import _root_.scala.pickling._
         |import _root_.scala.pickling.json._
         |

--- a/core/src/test/scala/pickling/neg/static-only-fail-1.scala
+++ b/core/src/test/scala/pickling/neg/static-only-fail-1.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSuite
 
 class StaticOnlyFail1Test extends FunSuite {
   test("main") {
-    expectError("cannot generate fully static pickler") {
+    expectError("Cannot generate") {
       """
         | import _root_.scala.pickling._
         | import _root_.scala.pickling.json._

--- a/core/src/test/scala/pickling/neg/static-only-fail-2.scala
+++ b/core/src/test/scala/pickling/neg/static-only-fail-2.scala
@@ -1,0 +1,29 @@
+package scala.pickling.staticonlyfail2
+
+import scala.pickling._
+import NegativeCompilation._
+import org.scalatest.FunSuite
+
+class StaticOnlyFail2Test extends FunSuite {
+  test("main") {
+    expectError("cannot generate fully static pickler") {
+      """
+        | import _root_.scala.pickling._
+        | import _root_.scala.pickling.json._
+        | import _root_.scala.pickling.static.StaticOnly
+        |
+        | // this case is with an unsealed class
+        | // as part of a complicated hierarchy
+        | sealed trait C
+        | sealed trait D extends C
+        | final case class E(fld: Int) extends C
+        | case class F(bar: String) extends C
+        | // this is the class that makes it fail
+        | class G(foo: Double) extends D
+        |
+        | val x: C = E(1)
+        | val pickle: JSONPickle = x.pickle
+      """.stripMargin
+    }
+  }
+}

--- a/core/src/test/scala/pickling/neg/static-only-fail-2.scala
+++ b/core/src/test/scala/pickling/neg/static-only-fail-2.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSuite
 
 class StaticOnlyFail2Test extends FunSuite {
   test("main") {
-    expectError("cannot generate fully static pickler") {
+    expectError("Cannot generate") {
       """
         | import _root_.scala.pickling._
         | import _root_.scala.pickling.json._

--- a/core/src/test/scala/pickling/neg/static-only-fail-3.scala
+++ b/core/src/test/scala/pickling/neg/static-only-fail-3.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSuite
 
 class StaticOnlyFail3Test extends FunSuite {
   test("main") {
-    expectError("cannot generate fully static pickler") {
+    expectError("Cannot generate") {
       """
         | import _root_.scala.pickling._
         | import _root_.scala.pickling.json._

--- a/core/src/test/scala/pickling/neg/static-only-fail-3.scala
+++ b/core/src/test/scala/pickling/neg/static-only-fail-3.scala
@@ -1,0 +1,25 @@
+package scala.pickling.staticonlyfail3
+
+import scala.pickling._
+import NegativeCompilation._
+import org.scalatest.FunSuite
+
+class StaticOnlyFail3Test extends FunSuite {
+  test("main") {
+    expectError("cannot generate fully static pickler") {
+      """
+        | import _root_.scala.pickling._
+        | import _root_.scala.pickling.json._
+        | import _root_.scala.pickling.static.StaticOnly
+        |
+        | // this case has a type parameter on a
+        | // subtype in the hierarchy
+        | sealed trait C
+        | final case class D[T](fld: T) extends C
+        |
+        | val x: C = D(1)
+        | val pickle: JSONPickle = x.pickle
+      """.stripMargin
+    }
+  }
+}

--- a/core/src/test/scala/pickling/run/forwarded-pickler.scala
+++ b/core/src/test/scala/pickling/run/forwarded-pickler.scala
@@ -1,0 +1,33 @@
+package scala.pickling.forwardedpickler
+
+import org.scalatest.FunSuite
+import scala.pickling._
+import json._
+import static.StaticOnly
+
+sealed trait F { val fld: Int }
+
+final case class G(fld: Int) extends F
+final case class H(fld: Int) extends F
+
+class PicklerCanBeForwarded extends FunSuite {
+
+  // we should be able to use a passed-in implicit pickler
+  // rather than trying to generate one, this allows people
+  // to call pickle/unpickle in a different place from the
+  // spot where they generate the pickler.
+
+  // TODO remove the FastTypeTag implicit parameters when possible
+
+  private def doPickle[T](t: T)(implicit pickler1: SPickler[T], tag1: FastTypeTag[T]): JSONPickle =
+    t.pickle
+
+  private def doUnpickle[T](p: JSONPickle)(implicit unpickler1: Unpickler[T], tag1: FastTypeTag[T]): T =
+    p.unpickle[T]
+
+  test("main") {
+    val x: F = G(42)
+    val pickle: JSONPickle = doPickle(x)
+    assert(doUnpickle[F](pickle).fld == 1)
+  }
+}

--- a/core/src/test/scala/pickling/run/forwarded-pickler.scala
+++ b/core/src/test/scala/pickling/run/forwarded-pickler.scala
@@ -5,6 +5,12 @@ import scala.pickling._
 import json._
 import static.StaticOnly
 
+/* Note: importing AllPicklers.{genPickler, genUnpickler} leads to issues
+         if the primitive picklers are *not* imported at the same time!
+         (e.g., the *generated* pickler for type `Int` is nonsense)
+ */
+import AllPicklers._
+
 sealed trait F { val fld: Int }
 
 final case class G(fld: Int) extends F
@@ -16,18 +22,15 @@ class PicklerCanBeForwarded extends FunSuite {
   // rather than trying to generate one, this allows people
   // to call pickle/unpickle in a different place from the
   // spot where they generate the pickler.
-
-  // TODO remove the FastTypeTag implicit parameters when possible
-
-  private def doPickle[T](t: T)(implicit pickler1: SPickler[T], tag1: FastTypeTag[T]): JSONPickle =
+  private def doPickle[T](t: T)(implicit pickler1: SPickler[T]): JSONPickle =
     t.pickle
 
-  private def doUnpickle[T](p: JSONPickle)(implicit unpickler1: Unpickler[T], tag1: FastTypeTag[T]): T =
+  private def doUnpickle[T](p: JSONPickle)(implicit unpickler1: Unpickler[T]): T =
     p.unpickle[T]
 
   test("main") {
     val x: F = G(42)
     val pickle: JSONPickle = doPickle(x)
-    assert(doUnpickle[F](pickle).fld == 1)
+    assert(doUnpickle[F](pickle).fld == 42)
   }
 }

--- a/core/src/test/scala/pickling/run/static-only-with-manual-pickler.scala
+++ b/core/src/test/scala/pickling/run/static-only-with-manual-pickler.scala
@@ -22,6 +22,7 @@ class StaticOnlyWithManualPicklerTest extends FunSuite {
         throw FakeImplementation()
       def unpickle(tag: => FastTypeTag[_], reader: PReader): Any =
         throw FakeImplementation()
+      def tag = FastTypeTag[NotClosed]
     }
     val pickle: JSONPickle = try {
       x.pickle
@@ -33,7 +34,8 @@ class StaticOnlyWithManualPicklerTest extends FunSuite {
       pickle.unpickle[NotClosed]
       throw new AssertionError("Should have used the fake implementation unpickler")
     } catch {
-      case FakeImplementation() =>
+      case PicklingException(msg, cause) =>
+        assert(msg.contains("failed to parse"))
     }
   }
 }

--- a/core/src/test/scala/pickling/run/static-only-with-manual-pickler.scala
+++ b/core/src/test/scala/pickling/run/static-only-with-manual-pickler.scala
@@ -1,0 +1,39 @@
+package scala.pickling.staticonlywithmanualpickler
+
+import org.scalatest.FunSuite
+import scala.pickling._
+import json._
+import static.StaticOnly
+
+// NOT sealed so StaticOnly should block generating
+// a pickler.
+class NotClosed(fld: Int)
+
+case class FakeImplementation() extends Exception("Not a real implementation")
+
+class StaticOnlyWithManualPicklerTest extends FunSuite {
+  test("main") {
+    val x: NotClosed = new NotClosed(42)
+    // StaticOnly should be happy with us, because
+    // we define this pickler. If we remove this, then
+    // this file should not compile.
+    implicit val picklerUnpickler: SPickler[NotClosed] with Unpickler[NotClosed] = new SPickler[NotClosed] with Unpickler[NotClosed] {
+      def pickle(picklee: NotClosed, builder: PBuilder): Unit =
+        throw FakeImplementation()
+      def unpickle(tag: => FastTypeTag[_], reader: PReader): Any =
+        throw FakeImplementation()
+    }
+    val pickle: JSONPickle = try {
+      x.pickle
+      throw new AssertionError("Should have used the fake implementation pickler")
+    } catch {
+      case FakeImplementation() => JSONPickle("")
+    }
+    try {
+      pickle.unpickle[NotClosed]
+      throw new AssertionError("Should have used the fake implementation unpickler")
+    } catch {
+      case FakeImplementation() =>
+    }
+  }
+}

--- a/core/src/test/scala/pickling/run/static-only.scala
+++ b/core/src/test/scala/pickling/run/static-only.scala
@@ -6,13 +6,31 @@ import json._
 import AllPicklers._
 import static.StaticOnly
 
-sealed abstract class C { val fld: Int }
+sealed trait A
+
+sealed trait B extends A
+
+sealed abstract class C extends B { val fld: Int }
 
 final class D extends C { val fld = 1 }
 
 final class E extends C {
   val fld = 2
   def incr(x: Int) = x + 1
+}
+
+// case class should work whether final or not
+final case class F(bar: Int) extends A
+case class G(bar: Int) extends A
+
+// case class should work when extending B or C too
+final case class H(bar: Int) extends B
+final case class I(fld: Int) extends C
+
+// companion object should not matter
+case class J(baz: Long) extends B
+object J {
+  def apply(s: String): J = J(Integer.parseInt(s))
 }
 
 class StaticOnlyTest extends FunSuite {


### PR DESCRIPTION
This PR supersedes #249. It includes all its commits, which add the following tests:

- more complex static-only test
- test we detect unclosed types deep in a hierarchy
- test we detect a parameterized type as not static-only
- test we can get the pickler from a parameter instead of from the macro

This PR adds the following significant refactoring:
- Moves all dispatch logic from `PickleMacros` to `PicklerMacros`. It is a big step towards turning the `pickle` macro into a regular method.
- Removes `PicklerUnpicklerNotFound`, which was the cause of runtime errors in the past, besides preventing some of these new tests to work.