### PR TITLE
The many steps of static-pickle/unpickle methods

### DIFF
--- a/benchmark/ArrayIntBench.scala
+++ b/benchmark/ArrayIntBench.scala
@@ -1,5 +1,6 @@
 import scala.pickling._
 import binary._
+import AllPicklers._
 
 object ArrayIntBench extends scala.pickling.testing.PicklingBenchmark {
   val coll = (1 to size).toArray

--- a/benchmark/Evactor.scala
+++ b/benchmark/Evactor.scala
@@ -1,5 +1,6 @@
 import scala.pickling._
 import binary._
+import AllPicklers._
 
 import org.evactor.model.events.DataEvent
 import scala.util.Random

--- a/benchmark/GeoTrellis.scala
+++ b/benchmark/GeoTrellis.scala
@@ -1,5 +1,6 @@
 import scala.pickling._
 import binary._
+import AllPicklers._
 
 import java.io._
 import scala.util.Random

--- a/benchmark/ListIntBench.scala
+++ b/benchmark/ListIntBench.scala
@@ -1,5 +1,6 @@
 import scala.pickling._
 import binary._
+import AllPicklers._
 
 object ListIntBench extends scala.pickling.testing.PicklingBenchmark {
   val lst = (1 to size).toList

--- a/benchmark/SparkLR.scala
+++ b/benchmark/SparkLR.scala
@@ -1,5 +1,6 @@
 import scala.pickling._
 import binary._
+import AllPicklers._
 import java.io._
 import scala.util.Random
 

--- a/benchmark/TraversableIntBench.scala
+++ b/benchmark/TraversableIntBench.scala
@@ -3,6 +3,7 @@ import scala.util.Random
 
 import scala.pickling._
 import binary._
+import AllPicklers._
 
 // for Java Serialization:
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream, ObjectInputStream}

--- a/benchmark/TraversableIntBenchFreeMem.scala
+++ b/benchmark/TraversableIntBenchFreeMem.scala
@@ -3,6 +3,7 @@ import scala.util.Random
 
 import scala.pickling._
 import binary._
+import AllPicklers._
 import java.lang.{Runtime => JRuntime}
 
 // for Java Serialization:

--- a/benchmark/TraversableIntBenchSize.scala
+++ b/benchmark/TraversableIntBenchSize.scala
@@ -3,6 +3,7 @@ import scala.util.Random
 
 import scala.pickling._
 import binary._
+import AllPicklers._
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream, ObjectInputStream}
 

--- a/benchmark/VectorIntGeneratedBench.scala
+++ b/benchmark/VectorIntGeneratedBench.scala
@@ -1,5 +1,6 @@
 import scala.pickling._
 import binary._
+import AllPicklers._
 
 object VectorIntGeneratedBench extends scala.pickling.testing.PicklingBenchmark {
   val vec = (1 to size).toVector

--- a/benchmark/WikiGraph.scala
+++ b/benchmark/WikiGraph.scala
@@ -12,6 +12,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream,
 
 import scala.pickling._
 import binary._
+import AllPicklers._
 
 // for invalid characters in source files
 import java.nio.charset.CodingErrorAction
@@ -165,7 +166,8 @@ object WikiGraphPicklingBench extends WikiGraphBenchmark {
   implicit val VectorVertexTag = FastTypeTag.materializeFastTypeTag[Vector[Vertex]]
   implicit val ListVertexTag = FastTypeTag.materializeFastTypeTag[List[Vertex]]
   implicit val NilTag = FastTypeTag.materializeFastTypeTag[Nil.type]
-  implicit val picklerNil = implicitly[SPickler[Nil.type]]
+  // TODO - why does this no longer compile?
+  implicit val picklerNil = DPickler.genDPickler[Nil.type] 
   implicit val unpicklerNil = implicitly[Unpickler[Nil.type]]
   implicit lazy val picklerVertex: SPickler[Vertex] = {
     val picklerVertex = "boom!"
@@ -220,8 +222,8 @@ object WikiGraphPicklingBench extends WikiGraphBenchmark {
   //     }
   //   }
   // }
-  implicit lazy val picklerUnpicklerColonColonVertex: SPickler[::[Vertex]] with Unpickler[::[Vertex]] = SPickler.genListPickler[Vertex]
-  implicit lazy val picklerUnpicklerVectorVertex: SPickler[Vector[Vertex]] with Unpickler[Vector[Vertex]] = SPickler.vectorPickler[Vertex]
+  implicit lazy val picklerUnpicklerColonColonVertex: SPickler[::[Vertex]] with Unpickler[::[Vertex]] = implicitly
+  implicit lazy val picklerUnpicklerVectorVertex: SPickler[Vector[Vertex]] with Unpickler[Vector[Vertex]] = all.vectorPickler[Vertex]
   implicit val picklerGraph = implicitly[SPickler[Graph]]
   implicit val unpicklerGraph = implicitly[Unpickler[Graph]]
 

--- a/core/src/main/scala/pickling/AllPicklers.scala
+++ b/core/src/main/scala/pickling/AllPicklers.scala
@@ -8,17 +8,14 @@ object AllPicklers extends CorePicklersUnpicklers
 object all extends CorePicklersUnpicklers {
 
   implicit class PickleOps[T](picklee: T) {
-    //def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
     def pickle(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType =
       scala.pickling.pickle[T](picklee)(format, pickler)
-    //def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]
     def pickleInto(builder: PBuilder)(implicit pickler: SPickler[T]): Unit =
       scala.pickling.pickleInto(picklee, builder)(pickler)
     def pickleTo[S](output: S)(implicit format: PickleFormat): Unit = macro Compat.PickleMacros_pickleTo[T,S]
   }
 
   implicit class UnpickleOps(val thePickle: Pickle) {
-    //def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T = macro Compat.UnpickleMacros_pickleUnpickle[T]
     def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T =
        // TODO - Ideally we get a compiler error if pickle type doesn't match.
        scala.pickling.unpickle(thePickle.asInstanceOf[format.PickleType])(unpickler, format)

--- a/core/src/main/scala/pickling/AllPicklers.scala
+++ b/core/src/main/scala/pickling/AllPicklers.scala
@@ -8,8 +8,12 @@ object AllPicklers extends CorePicklersUnpicklers
 object all extends CorePicklersUnpicklers {
 
   implicit class PickleOps[T](picklee: T) {
-    def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
-    def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]
+    //def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
+    def pickle(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType =
+      scala.pickling.pickle[T](picklee)(format, pickler)
+    //def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]
+    def pickleInto(builder: PBuilder)(implicit pickler: SPickler[T]): Unit =
+      scala.pickling.pickleInto(picklee, builder)(pickler)
     def pickleTo[S](output: S)(implicit format: PickleFormat): Unit = macro Compat.PickleMacros_pickleTo[T,S]
   }
 

--- a/core/src/main/scala/pickling/AllPicklers.scala
+++ b/core/src/main/scala/pickling/AllPicklers.scala
@@ -14,7 +14,10 @@ object all extends CorePicklersUnpicklers {
   }
 
   implicit class UnpickleOps(val thePickle: Pickle) {
-    def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T = macro Compat.UnpickleMacros_pickleUnpickle[T]
+    //def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T = macro Compat.UnpickleMacros_pickleUnpickle[T]
+    def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T =
+       // TODO - Ideally we get a compiler error if pickle type doesn't match.
+       scala.pickling.unpickle(thePickle.asInstanceOf[format.PickleType])(unpickler, format)
   }
 
 }

--- a/core/src/main/scala/pickling/Compat.scala
+++ b/core/src/main/scala/pickling/Compat.scala
@@ -31,42 +31,10 @@ object Compat {
     c.Expr[Unpickler[T] with Generated](bundle.impl[T])
   }
 
-  def PickleMacros_pickle[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[format.value.PickleType] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with PickleMacros
-    c.Expr[format.value.PickleType](bundle.pickle[T](format.tree))
-  }
-
-  def PickleMacros_pickleInto[T: c.WeakTypeTag](c: Context)(builder: c.Expr[PBuilder]): c.Expr[Unit] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with PickleMacros
-    c.Expr[Unit](bundle.pickleInto[T](builder.tree))
-  }
-
   def PickleMacros_pickleTo[T: c.WeakTypeTag, S](c: Context)(output: c.Expr[S])(format: c.Expr[PickleFormat]): c.Expr[Unit] = {
     val c0: c.type = c
     val bundle = new { val c: c0.type = c0 } with PickleMacros
     c.Expr[Unit](bundle.pickleTo[T](output.tree)(format.tree))
-  }
-
-  def UnpickleMacros_pickleUnpickle[T: c.WeakTypeTag](c: Context)(unpickler: c.Expr[Unpickler[T]], format: c.Expr[PickleFormat]): c.Expr[T] = {
-    import c.universe._
-    val c0: c.type = c
-    val tpe = c.universe.weakTypeOf[T]
-    // abort if someone forgets to pass a type parameter to the unpickle method
-    val isNothing = tpe =:= definitions.NothingTpe
-    val unpickleSym = c.mirror.staticClass("scala.pickling.UnpickleOps").asType.toType.member(newTermName("unpickle"))
-    val typeArgMissing = tpe match {
-      case t: TypeRef => t.typeSymbol.owner == unpickleSym || isNothing
-      case _ => false
-    }
-    if (typeArgMissing)
-      c.abort(c.enclosingPosition, """cannot unpickle because the (inferred) type argument of unpickle is abstract.
-        |Typically, this is caused by omitting an explicit type argument. Always invoke unpickle with a concrete
-        |type argument, for example, unpickle[Int]""".stripMargin)
-
-    val bundle = new { val c: c0.type = c0 } with UnpickleMacros
-    c.Expr[T](bundle.pickleUnpickle[T])
   }
 
   def ListPicklerUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[T] with Unpickler[T]] = {

--- a/core/src/main/scala/pickling/Custom.scala
+++ b/core/src/main/scala/pickling/Custom.scala
@@ -370,11 +370,15 @@ trait CorePicklersUnpicklers extends GenPicklers with GenUnpicklers with LowPrio
 
   class PrimitivePicklerUnpickler[T: FastTypeTag](name: String) extends AutoRegister[T](name) {
     def pickle(picklee: T, builder: PBuilder): Unit = {
+      // TODO - figure out this is the right thing to do, and if
+      // we should denote it's statically elidable...
+      builder.hintTag(tag)
       builder.beginEntry(picklee)
       builder.endEntry()
     }
     def unpickle(tag: String, reader: PReader): Any = {
       try {
+        reader.hintTag(this.tag)
         reader.readPrimitive()
       } catch {
         case PicklingException(msg, cause) =>

--- a/core/src/main/scala/pickling/Custom.scala
+++ b/core/src/main/scala/pickling/Custom.scala
@@ -418,6 +418,7 @@ trait CorePicklersUnpicklers extends GenPicklers with GenUnpicklers with LowPrio
 trait ListPicklerUnpicklerMacro extends CollectionPicklerUnpicklerMacro {
   import c.universe._
   import definitions._
+  // TODO - Lock this by GRL
   lazy val ConsClass = c.mirror.staticClass("scala.collection.immutable.$colon$colon")
   def mkType(eltpe: c.Type) = appliedType(ConsClass.toTypeConstructor, List(eltpe))
   def mkArray(picklee: c.Tree) = q"$picklee.toArray"

--- a/core/src/main/scala/pickling/Custom.scala
+++ b/core/src/main/scala/pickling/Custom.scala
@@ -22,7 +22,7 @@ trait LowPriorityPicklersUnpicklers {
 
   // Any
   implicit object anyUnpickler extends Unpickler[Any] {
-    def unpickle(tag: => FastTypeTag[_], reader: PReader): Any = {
+    def unpickle(tag: String, reader: PReader): Any = {
       val actualUnpickler = RuntimeUnpicklerLookup.genUnpickler(scala.reflect.runtime.currentMirror, tag)
       actualUnpickler.unpickle(tag, reader)
     }
@@ -116,7 +116,7 @@ trait LowPriorityPicklersUnpicklers {
       builder.endEntry()
     }
 
-    def unpickle(tpe: => FastTypeTag[_], preader: PReader): Any = {
+    def unpickle(tpe: String, preader: PReader): Any = {
       val reader = preader.beginCollection()
 
       preader.pushHints()
@@ -131,9 +131,7 @@ trait LowPriorityPicklersUnpicklers {
       var i = 0
       while (i < length) {
         val r = reader.readElement()
-        r.beginEntryNoTag()
-        val elem = elemUnpickler.unpickle(elemTag, r)
-        r.endEntry()
+        val elem = elemUnpickler.unpickleEntry(r)
         builder += elem.asInstanceOf[T]
         i = i + 1
       }
@@ -234,7 +232,7 @@ trait CollectionPicklerUnpicklerMacro extends Macro with UnpickleMacros {
           builder.endCollection()
           builder.endEntry()
         }
-        def unpickle(tag: => scala.pickling.FastTypeTag[_], reader: PReader): Any = {
+        def unpickle(tag: String, reader: PReader): Any = {
           val arrReader = reader.beginCollection()
           ${
             if (isPrimitive) q"arrReader.hintStaticallyElidedType(); arrReader.hintTag(eltag); arrReader.pinHints()".asInstanceOf[Tree]
@@ -247,7 +245,7 @@ trait CollectionPicklerUnpicklerMacro extends Macro with UnpickleMacros {
             val r = arrReader.readElement()
             ${
               if (isPrimitive) q"""
-                r.beginEntryNoTag()
+                r.beginEntry()
                 val elem = elunpickler.unpickle(eltag, r).asInstanceOf[$eltpe]
                 r.endEntry()
                 buffer += elem
@@ -293,15 +291,11 @@ trait CorePicklersUnpicklers extends GenPicklers with GenUnpicklers with LowPrio
 
       builder.endEntry()
     }
-    def unpickle(tag: => FastTypeTag[_], reader: PReader): Any = {
+    def unpickle(tag: String, reader: PReader): Any = {
       val reader1 = reader.readField("value")
       reader1.hintTag(implicitly[FastTypeTag[String]])
       reader1.hintStaticallyElidedType()
-
-      val tag = reader1.beginEntry()
-      val result = stringPicklerUnpickler.unpickle(tag, reader1)
-      reader1.endEntry()
-
+      val result = stringPicklerUnpickler.unpickleEntry(reader1)
       new BigDecimal(result.asInstanceOf[String])
     }
   }
@@ -319,7 +313,7 @@ trait CorePicklersUnpicklers extends GenPicklers with GenUnpicklers with LowPrio
 
       builder.endEntry()
     }
-    def unpickle(tag: => FastTypeTag[_], reader: PReader): Any = {
+    def unpickle(tag: String, reader: PReader): Any = {
       val reader1 = reader.readField("value")
       reader1.hintTag(implicitly[FastTypeTag[String]])
       reader1.hintStaticallyElidedType()
@@ -353,7 +347,7 @@ trait CorePicklersUnpicklers extends GenPicklers with GenUnpicklers with LowPrio
 
       builder.endEntry()
     }
-    def unpickle(tag: => FastTypeTag[_], reader: PReader): Any = {
+    def unpickle(tag: String, reader: PReader): Any = {
       val reader1 = reader.readField("value")
       reader1.hintTag(implicitly[FastTypeTag[String]])
       reader1.hintStaticallyElidedType()
@@ -379,13 +373,13 @@ trait CorePicklersUnpicklers extends GenPicklers with GenUnpicklers with LowPrio
       builder.beginEntry(picklee)
       builder.endEntry()
     }
-    def unpickle(tag: => FastTypeTag[_], reader: PReader): Any = {
+    def unpickle(tag: String, reader: PReader): Any = {
       try {
         reader.readPrimitive()
       } catch {
         case PicklingException(msg, cause) =>
           throw PicklingException(s"""error in unpickle of primitive unpickler '$name':
-                                     |tag in unpickle: '${tag.key}'
+                                     |tag in unpickle: '${tag}'
                                      |message:
                                      |$msg""".stripMargin, cause)
       }

--- a/core/src/main/scala/pickling/Macros.scala
+++ b/core/src/main/scala/pickling/Macros.scala
@@ -38,6 +38,7 @@ trait TypeAnalysis extends Macro {
 trait PicklerMacros extends Macro with PickleMacros with FastTypeTagMacros {
   import c.universe._
 
+  // TODO - We should use the GRL to lock the reflection in the TypeTag + Runtime lookup.
   def createRuntimePickler(builder: c.Tree): c.Tree = q"""
     val classLoader = this.getClass.getClassLoader
     val tag = scala.pickling.FastTypeTag.mkRaw(clazz, scala.reflect.runtime.universe.runtimeMirror(classLoader))
@@ -557,6 +558,7 @@ trait UnpicklerMacros extends Macro with UnpickleMacros with FastTypeTagMacros {
             """
           else
             // FOR now we summon up a mirror using the currentMirror macro.
+            // TODO - we may need a more robust mechanism  of grabbing the currentMirror
             q"""
               val rtUnpickler = scala.pickling.runtime.RuntimeUnpicklerLookup.genUnpickler(scala.pickling.internal.`package`.currentMirror, tagKey)
               rtUnpickler.unpickle(tagKey, reader)

--- a/core/src/main/scala/pickling/PBuilderReader.scala
+++ b/core/src/main/scala/pickling/PBuilderReader.scala
@@ -148,8 +148,6 @@ trait PBuilder extends Hintable {
  *   - ArrayDouble
  */
 trait PReader extends Hintable {
-  /** The scala reflection mirror used when we need to do any runtime-reflection based unpickling. */
-  def mirror: Mirror
   /** Start reading a pickled value.  
    *  This will return any serialized type tag key string.   This string can be used
    *  to reconstitute a FastTypeTag w/ a mirror, but is intended for use as fast string-matching.

--- a/core/src/main/scala/pickling/PBuilderReader.scala
+++ b/core/src/main/scala/pickling/PBuilderReader.scala
@@ -3,7 +3,7 @@ package scala.pickling
 import scala.language.experimental.macros
 
 import scala.reflect.runtime.universe._
-
+// TODO - Document this, specifically what pinHints means.
 trait Hintable {
   def hintTag(tag: FastTypeTag[_]): this.type
   def hintKnownSize(knownSize: Int): this.type
@@ -16,29 +16,175 @@ trait Hintable {
   def popHints(): this.type
 }
 
+/**
+ * A builder of pickled content.  This is a mutable API, intended to be called in certain specific ways.
+ *
+ * Here are a few static rules that all picklers must follow when using this interface.
+ *
+ * 1. You will be given a type hint before any beginEntry() call.
+ * 2. There will be one endEntry() for every beginEntry() call.
+ * 3. There will be one endCollection() for every beginCollection() call.
+ * 4. Every beginCollection()/endCollection() pair will be inside a beginEntry()/endEntry() pair.
+ * 5. Every putElement() call must happen within a beginCollection()/endCollection() block.
+ * 6. Every putField() call must happen within a beginEntry()/endEntry() block.
+ * 7. There is no guarantee that putElement() will be called within a beginCollectoin()/endCollection() pair.
+ *    i.e. we can write empty collections.
+ * 8. There is no guarantee that putField will be called within a beginEntry()/endEntry() pair.
+ *    i.e. if we don't put any fields, this means the entry was for a "primitive" type, at least what
+ *    The pickling library considers primitives.
+ * 9. The order of putField calls in any pickler will be the exact same ordering when unpickling, if the format
+ *    is compatible.
+ *
+ * Here is a list of all types the auto-generated Picklers considers "primitives" and must be directly supported by
+ * any PBuilder:
+ *
+ *   - Nothing
+ *   - Null
+ *   - Unit
+ *   - Byte
+ *   - Char
+ *   - String
+ *   - Short
+ *   - Int
+ *   - Long
+ *   - Float
+ *   - Double
+ *   - Ref  (for circular object graphs)
+ *   - ArrayByte
+ *   - ArrayShort
+ *   - ArrayChar
+ *   - ArrayInt
+ *   - ArrayLong
+ *   - ArrayBoolean
+ *   - ArrayFloat
+ *   - ArrayDouble
+ */
 trait PBuilder extends Hintable {
+  /** Called to denote that an object is about to be serialized.
+    * @param picklee
+    *                The object to be serialized.  This may be a primtiive, in which case
+    *                it can be immediately serialized (or you can wait unitl endEntry is called).
+    * @return
+    *                A pbuilder instance a pickler can use to serialize the picklee, if it's a complex type.
+    */
   def beginEntry(picklee: Any): PBuilder
+  /**
+   * Serialize a "field" in a complex structure/object being pickled.
+   * @param name  The name of the field to serialize.
+   * @param pickler  A callback which will be passed an appropriate pickler.
+   *                 You should ensure this function will perform a beginEntry()/endEntry() block.
+   * @return A builder for remaining items in the current complex structure being pickled.
+   */
   def putField(name: String, pickler: PBuilder => Unit): PBuilder
+
+  /**
+   * Call this to denote that the given primitive, collection or structure being pickled is completed.
+   */
   def endEntry(): Unit
+
+  /**
+   * Denotes that a collection of elements is about to be pickled.
+   *
+   * Note: This must be called after beginEntry()
+   * @param length   The length of the collection being serialized.
+   * @return  A pickler which can serialzie the collection.
+   */
   def beginCollection(length: Int): PBuilder
+
+  /**
+   * Places the next element in the serialized collection.
+   *
+   * Note: This must be called after beginCollection().
+   * @param pickler  A callback which is passed a pickler able to serialize the item in the collection.
+   * @return  A pickler which can serialize the next element of the collection.
+   */
   def putElement(pickler: PBuilder => Unit): PBuilder
+  /** Denote that we are done serializing the collection. */
   def endCollection(): Unit
+  /** Return the resulting pickle of this builder. */
   def result(): Pickle
 }
 
+
+/**
+ * A reader of pickled content.  This is a mutable API, intended to be called in certain specific ways.
+ *
+ * Here are a few static rules that all picklers must follow when using this interface.
+ *
+ * 1. There must be a typeHint() before any beginEntry*() call.
+ * 2. There will be one endEntry() for every beginEntry() call.
+ * 3. There will be one endCollection() for every beginCollection() call.
+ * 4. Every beginCollection()/endCollection() pair will be inside a beginEntry()/endEntry() pair.
+ * 5. Every readLength() call will be immediately after a beginCollection() call.
+ * 6. Every readElement() call must happen within a beginCollection()/endCollection() block, and after a readLength().
+ * 7. Every readField() call must happen within a beginEntry()/endEntry() block.
+ * 8. If readLength() returns 0, there will be no called to readElement().
+ * 9. readField() will only be called where atObject would return true
+ * 10. readPrimitive will only be called when atPrimitive would return true
+ * 11. The order of readField calls in any pickler will be the exact same ordering when pickling,
+ *
+ * Here is a list of all types the auto-generated Picklers considers "primitives" and must be directly supported by
+ * any PReader "readPrimitive" operation:
+ *
+ *   - Nothing
+ *   - Null
+ *   - Unit
+ *   - Byte
+ *   - Char
+ *   - String
+ *   - Short
+ *   - Int
+ *   - Long
+ *   - Float
+ *   - Double
+ *   - Ref  (for circular object graphs)
+ *   - ArrayByte
+ *   - ArrayShort
+ *   - ArrayChar
+ *   - ArrayInt
+ *   - ArrayLong
+ *   - ArrayBoolean
+ *   - ArrayFloat
+ *   - ArrayDouble
+ */
 trait PReader extends Hintable {
+  /** The scala reflection mirror used when we need to do any runtime-reflection based unpickling. */
   def mirror: Mirror
+  /** start reading a pickled value, returning the serialized FastTypeTag[_], or our static type "hint" */
   def beginEntry(): FastTypeTag[_]
+  /** Start reading a pickled value, ignoring any type tag. */
   def beginEntryNoTag(): String
+  /** Start reading a pickler ignoring any TypeTag hints.
+    * @param debugOn  Whether or not to debug this usage.
+    * @return  A string representing the FastTypeTag.key,
+    */
   def beginEntryNoTagDebug(debugOn: Boolean): String
+  /** returns true if the reader is currently looking at a pickled primitive. */
   def atPrimitive: Boolean
+  /** Reads one of the supported primitive types from the pickler. */
   def readPrimitive(): Any
+  /** returns true if the reader is currently looking at a pickled object/structure. */
   def atObject: Boolean
+  /** Returns a reader which can read a field of
+    * a complex structure in the pickle.
+    * @param name  The name of the field
+    * @return  A reader which can read the structure's field.
+    */
   def readField(name: String): PReader
+  /** Denotes that we're done reading an entry in the pickle. */
   def endEntry(): Unit
+  /** Denotes we'd like to read the current entry as a collection.
+    * Note: Must be called after a beginEntry* call.
+    */
   def beginCollection(): PReader
+  /** Reads the length of a serialized collection.
+    * Must be called directly after beginCollection and before readElement.
+    * @return  The length of a serialized collection.
+    */
   def readLength(): Int
+  /** Returns a new Reader that can be used to read the next element in a collection.  */
   def readElement(): PReader
+  /** Denote that we are done reading a collection. */
   def endCollection(): Unit
 }
 

--- a/core/src/main/scala/pickling/PBuilderReader.scala
+++ b/core/src/main/scala/pickling/PBuilderReader.scala
@@ -111,7 +111,7 @@ trait PBuilder extends Hintable {
  *
  * Here are a few static rules that all picklers must follow when using this interface.
  *
- * 1. There must be a typeHint() before any beginEntry*() call.
+ * 1. There must be a typeHint() before any beginEntry() call.
  * 2. There will be one endEntry() for every beginEntry() call.
  * 3. There will be one endCollection() for every beginCollection() call.
  * 4. Every beginCollection()/endCollection() pair will be inside a beginEntry()/endEntry() pair.
@@ -150,15 +150,11 @@ trait PBuilder extends Hintable {
 trait PReader extends Hintable {
   /** The scala reflection mirror used when we need to do any runtime-reflection based unpickling. */
   def mirror: Mirror
-  /** start reading a pickled value, returning the serialized FastTypeTag[_], or our static type "hint" */
-  def beginEntry(): FastTypeTag[_]
-  /** Start reading a pickled value, ignoring any type tag. */
-  def beginEntryNoTag(): String
-  /** Start reading a pickler ignoring any TypeTag hints.
-    * @param debugOn  Whether or not to debug this usage.
-    * @return  A string representing the FastTypeTag.key,
-    */
-  def beginEntryNoTagDebug(debugOn: Boolean): String
+  /** Start reading a pickled value.  
+   *  This will return any serialized type tag key string.   This string can be used
+   *  to reconstitute a FastTypeTag w/ a mirror, but is intended for use as fast string-matching.
+   */
+  def beginEntry(): String
   /** returns true if the reader is currently looking at a pickled primitive. */
   def atPrimitive: Boolean
   /** Reads one of the supported primitive types from the pickler. */

--- a/core/src/main/scala/pickling/PickleFormat.scala
+++ b/core/src/main/scala/pickling/PickleFormat.scala
@@ -15,5 +15,5 @@ trait PickleFormat {
 
   def createBuilder(): PBuilder
   def createBuilder(out: OutputType): PBuilder
-  def createReader(pickle: PickleType, mirror: Mirror): PReader
+  def createReader(pickle: PickleType): PReader
 }

--- a/core/src/main/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/pickling/Pickler.scala
@@ -15,7 +15,11 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound(msg = "Cannot generate a pickler for ${T}. Recompile with -Xlog-implicits for details")
 trait SPickler[T] {
+  /** Uses the given builder to place 'primitive' values, or collections/structures, into the
+   *  builder.
+   */
   def pickle(picklee: T, builder: PBuilder): Unit
+  /** The fast type tag associated with this pickler. */
   def tag: FastTypeTag[T]
 }
 
@@ -44,16 +48,65 @@ trait GenPicklers {
 // this is important for the dispatch between custom and generated picklers
 trait Generated
 
+/** This is something which knowns how to reconstitute/materialize a type out of
+ *  a pickle reader.
+ */
 @implicitNotFound(msg = "Cannot generate an unpickler for ${T}. Recompile with -Xlog-implicits for details")
 trait Unpickler[T] {
-  def unpickle(tag: => FastTypeTag[_], reader: PReader): Any
+  // TODO - we'd like  to call this method unpickeRaw and the unpickleEntry method `unpickle`,
+  //        as there is some logic about how to use the reader encoded here.
+  /** Unpickles an entry out of hte reader.
+   *  
+   *  note:  This method ASSUMES beginEntry() has already been called and endEntry() will be
+   *         called immediately afterwards.
+   *
+   * @param tag  The FastTypeTag[_].key that was serialized with the entry *or* the type hint
+   *             which was provided when reading.  This is generally used by abstract type 
+   *             Unpicklers to delegate to the appropriate concrete unpickler.
+   * @param reader  The reader we can grab fields, primitives or collection items out of.
+   * @return Any an instance of the type we've unpickled.
+   */
+  def unpickle(tag: String, reader: PReader): Any
+  /** A mechanism of unpickling that also includes calling beginEntry()/endEntry(). 
+   *  Note: We assume anyone calling this will hint "staticallyElided" or "dynamicallyElided"
+   *        if needed.   Each Unpickler should make no assumptions about its own type.
+   */
+  def unpickleEntry(reader: PReader): Any = {
+    reader.hintTag(this.tag)
+    val tag = reader.beginEntry()
+    val result = unpickle(tag, reader)
+    reader.endEntry()
+    result
+  }
+  /** The fast type tag associated with this unpickler. */
   def tag: FastTypeTag[T]
 }
 
+/** Open sum pickler methods.
+ *
+ *  Open-sum means that we don't have a "closed" object hierarchy, and we need to resort
+ *  to runtime reflection to handle classes which we didn't know about when we compiled
+ *  the unpicler.
+ */
 trait GenOpenSumUnpicklers {
+  /** Generates an unpickler which can use runtime reflection to unpickle classes
+   * which were not known when this Unpickler was created.
+   *
+   * The unpickler will attempt to use as much static information as possible.
+   * While the [[GenUnpicklers.genUnpickler]] macro is able to be run in static-only mode,
+   * this macro *must* always resort to runtime reflection.
+   */
   implicit def genOpenSumUnpickler[T]: Unpickler[T] with Generated = macro Compat.OpenSumUnpicklerMacro_impl[T]
 }
 
 trait GenUnpicklers extends GenOpenSumUnpicklers {
+  /** Generates an unpickler which can rematerialize the given type.
+   *
+   *  Note: If this unpickler encounters a type the compiler does not know about, it will
+   *        resort to runtim reflection.  This can be disabled by ensuring you:
+   *        {{{ import scala.pickling.static.StaticOnly}}}
+   *        everywhere this macro is used.
+   *
+   */
   implicit def genUnpickler[T]: Unpickler[T] with Generated = macro Compat.UnpicklerMacros_impl[T]
 }

--- a/core/src/main/scala/pickling/Tools.scala
+++ b/core/src/main/scala/pickling/Tools.scala
@@ -417,6 +417,7 @@ abstract class Macro extends RichTypes { self =>
     val prologue = {
       if (!reflectivePrologueEmitted) {
         reflectivePrologueEmitted = true
+        // TODO - Do we need the GRL for this?
         val initMirror = q"""
           val mirror = scala.reflect.runtime.universe.runtimeMirror(this.getClass.getClassLoader)
           val im = mirror.reflect($target)

--- a/core/src/main/scala/pickling/binary/BinaryPickle.scala
+++ b/core/src/main/scala/pickling/binary/BinaryPickle.scala
@@ -14,14 +14,14 @@ abstract class BinaryPickle extends Pickle {
 
   val value: Array[Byte]
 
-  def createReader(mirror: Mirror, format: BinaryPickleFormat): PReader
+  def createReader(format: BinaryPickleFormat): PReader
 }
 
 case class BinaryPickleArray(data: Array[Byte]) extends BinaryPickle {
   val value: Array[Byte] = data
 
-  def createReader(mirror: Mirror, format: BinaryPickleFormat): PReader =
-    new BinaryPickleReader(new ByteArrayInput(data), mirror, format)
+  def createReader(format: BinaryPickleFormat): PReader =
+    new BinaryPickleReader(new ByteArrayInput(data), format)
     //new BinaryPickleReader(data, mirror, format)
 
   override def toString = s"""BinaryPickle(${value.mkString("[", ",", "]")})"""
@@ -30,8 +30,8 @@ case class BinaryPickleArray(data: Array[Byte]) extends BinaryPickle {
 case class BinaryInputPickle(input: BinaryInput) extends BinaryPickle {
   val value: Array[Byte] = Array.ofDim[Byte](0)
 
-  def createReader(mirror: Mirror, format: BinaryPickleFormat): PReader =
-    new BinaryPickleReader(input, mirror, format)
+  def createReader(format: BinaryPickleFormat): PReader =
+    new BinaryPickleReader(input, format)
 
   /* Do not override def toString to avoid traversing the input stream. */
 }
@@ -151,21 +151,13 @@ class BinaryPickleBuilder(format: BinaryPickleFormat, out: BinaryOutput) extends
 
 }
 
-abstract class AbstractBinaryReader(val mirror: Mirror) {
-  protected var _lastTagRead: FastTypeTag[_] = null
+abstract class AbstractBinaryReader() {
   protected var _lastTypeStringRead: String  = null
-
-  protected def lastTagRead: FastTypeTag[_] =
-    if (_lastTagRead != null)
-      _lastTagRead
-    else {
-      // assume _lastTypeStringRead != null
-      _lastTagRead = FastTypeTag(mirror, _lastTypeStringRead)
-      _lastTagRead
-    }
+  // TODO - ok to hack this?
+  def lastTagRead: String = _lastTypeStringRead
 }
 
-class BinaryPickleReader(in: BinaryInput, mirror: Mirror, format: BinaryPickleFormat) extends AbstractBinaryReader(mirror) with PReader with PickleTools {
+class BinaryPickleReader(in: BinaryInput, format: BinaryPickleFormat) extends AbstractBinaryReader() with PReader with PickleTools {
   import format._
   
   def beginEntry: String = {
@@ -205,12 +197,11 @@ class BinaryPickleReader(in: BinaryInput, mirror: Mirror, format: BinaryPickleFo
       }
     }
     if (res.isInstanceOf[String]) {
-      _lastTagRead = null
       _lastTypeStringRead = res.asInstanceOf[String]
       _lastTypeStringRead
     } else {
-      _lastTagRead = res.asInstanceOf[FastTypeTag[_]]
-      _lastTagRead.key
+      _lastTypeStringRead = res.asInstanceOf[FastTypeTag[_]].key
+      _lastTypeStringRead
     }
   }
 
@@ -219,10 +210,10 @@ class BinaryPickleReader(in: BinaryInput, mirror: Mirror, format: BinaryPickleFo
   //  lastTagRead
   //}
 
-  def atPrimitive: Boolean = primitives.contains(lastTagRead.key)
+  def atPrimitive: Boolean = primitives.contains(lastTagRead)
 
   def readPrimitive(): Any = {
-    val res = lastTagRead.key match {
+    val res = lastTagRead match {
       case KEY_NULL    => null
       case KEY_REF     => lookupUnpicklee(in.getInt)
       case KEY_BYTE    => in.getByte

--- a/core/src/main/scala/pickling/binary/BinaryPickle.scala
+++ b/core/src/main/scala/pickling/binary/BinaryPickle.scala
@@ -168,9 +168,7 @@ abstract class AbstractBinaryReader(val mirror: Mirror) {
 class BinaryPickleReader(in: BinaryInput, mirror: Mirror, format: BinaryPickleFormat) extends AbstractBinaryReader(mirror) with PReader with PickleTools {
   import format._
   
-  def beginEntryNoTagDebug(debug: Boolean): String = beginEntryNoTag
-
-  def beginEntryNoTag: String = {
+  def beginEntry: String = {
     val res: Any = withHints { hints =>
 
       if (hints.isElidedType && nullablePrimitives.contains(hints.tag.key)) {
@@ -216,10 +214,10 @@ class BinaryPickleReader(in: BinaryInput, mirror: Mirror, format: BinaryPickleFo
     }
   }
 
-  def beginEntry(): FastTypeTag[_] = {
-    beginEntryNoTag()
-    lastTagRead
-  }
+  //def beginEntry(): FastTypeTag[_] = {
+  //  beginEntryNoTag()
+  //  lastTagRead
+  //}
 
   def atPrimitive: Boolean = primitives.contains(lastTagRead.key)
 

--- a/core/src/main/scala/pickling/binary/BinaryPickleFormat.scala
+++ b/core/src/main/scala/pickling/binary/BinaryPickleFormat.scala
@@ -16,7 +16,7 @@ class BinaryPickleFormat extends PickleFormat with Constants {
   def createBuilder(out: BinaryOutput): BinaryPBuilder = new BinaryPickleBuilder(this, out)
   def createBuilder(out: java.nio.ByteBuffer): BinaryPBuilder = createBuilder(new ByteBufferOutput(out))
   def createBuilder(out: java.io.OutputStream): BinaryPBuilder = createBuilder(new StreamOutput(out))
-  def createReader(pickle: PickleType, mirror: Mirror) = pickle.createReader(mirror, this)
+  def createReader(pickle: PickleType) = pickle.createReader(this)
 }
 
 trait Constants {

--- a/core/src/main/scala/pickling/json/JSONPickleFormat.scala
+++ b/core/src/main/scala/pickling/json/JSONPickleFormat.scala
@@ -25,9 +25,9 @@ package json {
     type OutputType = Output[String]
     def createBuilder() = new JSONPickleBuilder(this, new StringOutput)
     def createBuilder(out: Output[String]): PBuilder = new JSONPickleBuilder(this, out)
-    def createReader(pickle: JSONPickle, mirror: Mirror) = {
+    def createReader(pickle: JSONPickle) = {
       JSON.parseRaw(pickle.value) match {
-        case Some(raw) => new JSONPickleReader(raw, mirror, this)
+        case Some(raw) => new JSONPickleReader(raw, this)
         case None => throw new PicklingException("failed to parse \"" + pickle.value + "\" as JSON")
       }
     }
@@ -164,7 +164,7 @@ package json {
     }
   }
 
-  class JSONPickleReader(var datum: Any, val mirror: Mirror, format: JSONPickleFormat) extends PReader with PickleTools {
+  class JSONPickleReader(var datum: Any, format: JSONPickleFormat) extends PReader with PickleTools {
     private var lastReadTag: String = null
     private val primitives = Map[String, () => Any](
       FastTypeTag.Unit.key -> (() => ()),
@@ -189,7 +189,7 @@ package json {
       FastTypeTag.ArrayDouble.key -> (() => datum.asInstanceOf[JSONArray].list.map(el => el.asInstanceOf[Double]).toArray)
     )
     private def mkNestedReader(datum: Any) = {
-      val nested = new JSONPickleReader(datum, mirror, format)
+      val nested = new JSONPickleReader(datum, format)
       if (this.areHintsPinned) {
         nested.pinHints()
         nested.hints = hints

--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -33,29 +33,29 @@ package object pickling {
     // TODO - This usually doesn't clear Picklee's, but should we?
     // TODO - GRL Lock
   }
-  def pickleTo[T, S](picklee: T, output: S)(implicit pickler: SPickler[T], format: PickleFormat): Unit = {
-  	// SUPER HACK POWER TIME! - We should probably find a way of ensuring S <:< format.OutputType...
-  	val builder = format.createBuilder(output.asInstanceOf[format.OutputType])
 
+  def pickleTo[T, F <: PickleFormat](picklee: T, output: F#OutputType)(implicit pickler: SPickler[T], format: F): Unit = {
+  	// Lesser HACK POWER TIME! - We should probably find a way of ensuring S <:< format.OutputType...
+  	val builder = format.createBuilder(output.asInstanceOf[format.OutputType])
   	pickleInto(picklee, builder)
   	// TODO - some mechanism to turn this off
   	internal.clearPicklees()
   }
 
+  /** Appends the pickle/pickleTo/pickleInto operations onto any type, assuming implicits picklers are available. */
   implicit class PickleOps[T](picklee: T) {
-
-    //def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
     def pickle(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType =
       scala.pickling.pickle[T](picklee)(format, pickler)
-    // Note: TONS of macros in picklers use this, so we leave it as is...
-    //def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]
     def pickleInto(builder: PBuilder)(implicit pickler: SPickler[T]): Unit =
       scala.pickling.pickleInto(picklee, builder)(pickler)
+    // pickleTo remains a macro so further type-checking of [S <:< format.OutputType] occurs,
+    // and any implicit conversions required for this.
     def pickleTo[S](output: S)(implicit format: PickleFormat): Unit = macro Compat.PickleMacros_pickleTo[T,S]
+    //def pickleTo[S](output: S)(implicit format: PickleFormat, pickler: SPickler[T]): Unit =
+    //  scala.pickling.pickleTo(picklee, output)(pickler, format)
   }
 
   implicit class UnpickleOps(val thePickle: Pickle) {
-    //def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T = macro Compat.UnpickleMacros_pickleUnpickle[T]
     def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T =
        // TODO - Ideally we get a compiler error if pickle type doesn't match.
        scala.pickling.unpickle(thePickle.asInstanceOf[format.PickleType])(unpickler, format)

--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -5,6 +5,34 @@ import scala.language.experimental.macros
 
 package object pickling {
 
+  def unpickle[T](thePickle: Pickle)(implicit unpickler: Unpickler[T], format: PickleFormat): T = {
+  	val reader = format.createReader(thePickle.asInstanceOf[format.PickleType])
+  	val result = unpickler.unpickleEntry(reader).asInstanceOf[T]
+  	// TODO - some mechanism to disable this.
+  	internal.clearUnpicklees();
+  	result
+  }
+  def pickle[T](picklee: T)(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType = {
+  	val builder = format.createBuilder
+  	pickleInto(picklee, builder)
+  	// TODO - some mechanism to disable this.
+  	internal.clearPicklees()
+  	builder.result.asInstanceOf[format.PickleType]
+  }
+  def pickleInto[T](picklee: T, builder: PBuilder)(implicit pickler: SPickler[T]): Unit = {
+  	// TODO - BeginEntry/EndEntry needed?
+  	pickler.pickle(picklee, builder)
+    // TODO - This usually doesn't clear Picklee's, but should we?
+    // TODO - GRL Lock
+  }
+  def pickleTo[T, S](picklee: T, output: S)(implicit pickler: SPickler[T], format: PickleFormat): Unit = {
+  	// SUPER HACK POWER TIME! - We should probably find a way of ensuring S <:< format.OutputType...
+  	val builder = format.createBuilder(output.asInstanceOf[format.OutputType])
+  	pickleInto(picklee, builder)
+  	// TODO - some mechanism to turn this off
+  	internal.clearPicklees()
+  }
+
   implicit class PickleOps[T](picklee: T) {
     def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
     def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]

--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -6,11 +6,15 @@ import scala.language.experimental.macros
 package object pickling {
 
   def unpickle[T](thePickle: Pickle)(implicit unpickler: Unpickler[T], format: PickleFormat): T = {
-  	val reader = format.createReader(thePickle.asInstanceOf[format.PickleType])
-  	val result = unpickler.unpickleEntry(reader).asInstanceOf[T]
-  	// TODO - some mechanism to disable this.
-  	internal.clearUnpicklees();
-  	result
+  	// TODO - move GRL locking code into just the runtime unpickler code + generators.
+  	internal.GRL.lock()
+  	try {
+  	  val reader = format.createReader(thePickle.asInstanceOf[format.PickleType])
+  	  val result = unpickler.unpickleEntry(reader).asInstanceOf[T]
+  	  // TODO - some mechanism to disable this.
+  	  internal.clearUnpicklees();
+  	  result
+  	} finally internal.GRL.unlock()
   }
   def pickle[T](picklee: T)(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType = {
   	val builder = format.createBuilder
@@ -23,22 +27,25 @@ package object pickling {
   	// TODO - BeginEntry/EndEntry needed?
   	// TODO - this hinting should be in the pickler, not here.  We need to understand
   	//        when we want to use this vs. something else.
-  	if(null == picklee) {
-  	  builder.hintTag(FastTypeTag.Null)
-  	  all.nullPicklerUnpickler.pickle(null, builder)
-  	} else {
-  	  builder.hintTag(pickler.tag)
-  	  pickler.pickle(picklee, builder)
-  	}
+  	// TODO - Move GRL Lock only into dynamic picklers
+  	internal.GRL.lock()
+  	try { 
+  	  if(null == picklee) {
+  	    builder.hintTag(FastTypeTag.Null)
+  	    all.nullPicklerUnpickler.pickle(null, builder)
+  	  } else {
+  	    builder.hintTag(pickler.tag)
+  	    pickler.pickle(picklee, builder)
+  	  }
+  	  } finally internal.GRL.unlock()
     // TODO - This usually doesn't clear Picklee's, but should we?
-    // TODO - GRL Lock
   }
 
   def pickleTo[T, F <: PickleFormat](picklee: T, output: F#OutputType)(implicit pickler: SPickler[T], format: F): Unit = {
   	// Lesser HACK POWER TIME! - We should probably find a way of ensuring S <:< format.OutputType...
   	val builder = format.createBuilder(output.asInstanceOf[format.OutputType])
   	pickleInto(picklee, builder)
-  	// TODO - some mechanism to turn this off
+  	// TODO - some mechanism to turn this off, also should we have the GRL for this?
   	internal.clearPicklees()
   }
 

--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -5,84 +5,14 @@ import scala.language.experimental.macros
 
 package object pickling {
 
-
-   /** Raw/static pickle method which, given an implicit format and Pickler, can serialize
-    *  data into the pickle type.
-    */
-   def pickle[T](picklee: T)(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType = {
-     val builder = format.createBuilder()
-     scala.pickling.pickleInto(picklee, builder)
-     // TODO - We should look up whether or not to do this based on available implicits (I think)
-     internal.clearPicklees()
-     builder.result.asInstanceOf[format.PickleType]
-   }
-   /** Raw/Static method which will feed a given object/type into a builder. */
-   def pickleInto[T](picklee: T, builder: PBuilder)(implicit pickler: SPickler[T]): Unit = {
-   	 // TODO - Don't force pickling lock unless we're pickling into something dynamic.
-   	 scala.pickling.internal.GRL.lock()
-   	 try {
-       if(picklee != null) {
-         builder.hintTag(pickler.tag)
-         pickler.pickle(picklee, builder)
-       } else {
-         builder.hintTag(scala.pickling.FastTypeTag.Null)
-         scala.pickling.AllPicklers.nullPicklerUnpickler.pickle(null, builder)
-       }
-     } finally scala.pickling.internal.GRL.unlock()
-   }
-
-  // NOTE - The static versoin of this method is WAY more annoying to use than
-  //        the convenient macros in PickleOps.
-  def pickleTo[T](format: PickleFormat)(picklee: T, output: format.OutputType)(implicit pickler: SPickler[T]): Unit = {
-    import scala.pickling._
-    import scala.pickling.internal._
-    // TODO - This is a hack to convert an inner type into a path-dependent type.
-    //        This should *MOSTLY* be ok in the intended pickler usage, but is a hole someone
-    //        could trip over, that the macros would fix.
-    val builder = format.createBuilder(output)
-    scala.pickling.pickleInto(picklee, builder)(pickler)
-    // TODO - We should look up whether or not to do this based on available implicits (I think)
-    internal.clearPicklees()
-  }
-  import scala.reflect.runtime.{universe=>ru}
-  // Note: This should be "safe" to use if you guarantee no runtime reflection use, at ALL
-  //        in any pickleformat *or* unpickler.
-  def unpickleUnsafe[T](thePickle: Pickle, mirror: ru.Mirror)(implicit unpickler: Unpickler[T], format: PickleFormat): T = {
-    val reader = format.createReader(
-        thePickle.asInstanceOf[format.PickleType],  // Note: Macro is also unsafe here
-        mirror)
-    val result = unpickler.unpickleEntry(reader)
-    // TODO - We should look up whether or not to do this based on available implicits (I think)
-    internal.clearUnpicklees()
-    result.asInstanceOf[T]
-  }
-  /** Reconstitutes the data type inside a given Pickle. 
-   * @param thePickle  The pickle which contains a piece of data
-   * @param mirror   The mirror we use to reflectively restore types, if needed.
-   */
-  def unpickle[T](thePickle: Pickle, mirror: ru.Mirror)(implicit unpickler: Unpickler[T], format: PickleFormat): T = {
-      // We only unpickle in the midst of a lock against reflection, as it's unsafe
-      // to use in a threaded context.
-      scala.pickling.internal.GRL.lock()
-      try unpickleUnsafe(thePickle, mirror)(unpickler, format)
-      finally scala.pickling.internal.GRL.unlock()
-  }
-
   implicit class PickleOps[T](picklee: T) {
-    //def pickle(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType = 
-    //  scala.pickling.pickle(picklee)(format, pickler)
-    def pickle(implicit format: PickleFormat): format.PickleType = 
-      macro Compat.PickleMacros_pickle[T]
-    def pickleInto(builder: PBuilder)(implicit pickler: SPickler[T]): Unit = 
-      //macro Compat.PickleMacros_pickleInto[T]
-      scala.pickling.pickleInto(picklee, builder)(pickler)
-    def pickleTo[S](output: S)(implicit format: PickleFormat): Unit = 
-       macro Compat.PickleMacros_pickleTo[T,S]
+    def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
+    def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]
+    def pickleTo[S](output: S)(implicit format: PickleFormat): Unit = macro Compat.PickleMacros_pickleTo[T,S]
   }
 
   implicit class UnpickleOps(val thePickle: Pickle) {
-    def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T = 
-    macro Compat.UnpickleMacros_pickleUnpickle[T]
+    def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T = macro Compat.UnpickleMacros_pickleUnpickle[T]
   }
 
 }

--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -40,7 +40,10 @@ package object pickling {
   }
 
   implicit class UnpickleOps(val thePickle: Pickle) {
-    def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T = macro Compat.UnpickleMacros_pickleUnpickle[T]
+    //def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T = macro Compat.UnpickleMacros_pickleUnpickle[T]
+    def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T =
+       // TODO - Ideally we get a compiler error if pickle type doesn't match.
+       scala.pickling.unpickle(thePickle.asInstanceOf[format.PickleType])(unpickler, format)
   }
 
 }

--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -5,14 +5,84 @@ import scala.language.experimental.macros
 
 package object pickling {
 
+
+   /** Raw/static pickle method which, given an implicit format and Pickler, can serialize
+    *  data into the pickle type.
+    */
+   def pickle[T](picklee: T)(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType = {
+     val builder = format.createBuilder()
+     scala.pickling.pickleInto(picklee, builder)
+     // TODO - We should look up whether or not to do this based on available implicits (I think)
+     internal.clearPicklees()
+     builder.result.asInstanceOf[format.PickleType]
+   }
+   /** Raw/Static method which will feed a given object/type into a builder. */
+   def pickleInto[T](picklee: T, builder: PBuilder)(implicit pickler: SPickler[T]): Unit = {
+   	 // TODO - Don't force pickling lock unless we're pickling into something dynamic.
+   	 scala.pickling.internal.GRL.lock()
+   	 try {
+       if(picklee != null) {
+         builder.hintTag(pickler.tag)
+         pickler.pickle(picklee, builder)
+       } else {
+         builder.hintTag(scala.pickling.FastTypeTag.Null)
+         scala.pickling.AllPicklers.nullPicklerUnpickler.pickle(null, builder)
+       }
+     } finally scala.pickling.internal.GRL.unlock()
+   }
+
+  // NOTE - The static versoin of this method is WAY more annoying to use than
+  //        the convenient macros in PickleOps.
+  def pickleTo[T](format: PickleFormat)(picklee: T, output: format.OutputType)(implicit pickler: SPickler[T]): Unit = {
+    import scala.pickling._
+    import scala.pickling.internal._
+    // TODO - This is a hack to convert an inner type into a path-dependent type.
+    //        This should *MOSTLY* be ok in the intended pickler usage, but is a hole someone
+    //        could trip over, that the macros would fix.
+    val builder = format.createBuilder(output)
+    scala.pickling.pickleInto(picklee, builder)(pickler)
+    // TODO - We should look up whether or not to do this based on available implicits (I think)
+    internal.clearPicklees()
+  }
+  import scala.reflect.runtime.{universe=>ru}
+  // Note: This should be "safe" to use if you guarantee no runtime reflection use, at ALL
+  //        in any pickleformat *or* unpickler.
+  def unpickleUnsafe[T](thePickle: Pickle, mirror: ru.Mirror)(implicit unpickler: Unpickler[T], format: PickleFormat): T = {
+    val reader = format.createReader(
+        thePickle.asInstanceOf[format.PickleType],  // Note: Macro is also unsafe here
+        mirror)
+    val result = unpickler.unpickleEntry(reader)
+    // TODO - We should look up whether or not to do this based on available implicits (I think)
+    internal.clearUnpicklees()
+    result.asInstanceOf[T]
+  }
+  /** Reconstitutes the data type inside a given Pickle. 
+   * @param thePickle  The pickle which contains a piece of data
+   * @param mirror   The mirror we use to reflectively restore types, if needed.
+   */
+  def unpickle[T](thePickle: Pickle, mirror: ru.Mirror)(implicit unpickler: Unpickler[T], format: PickleFormat): T = {
+      // We only unpickle in the midst of a lock against reflection, as it's unsafe
+      // to use in a threaded context.
+      scala.pickling.internal.GRL.lock()
+      try unpickleUnsafe(thePickle, mirror)(unpickler, format)
+      finally scala.pickling.internal.GRL.unlock()
+  }
+
   implicit class PickleOps[T](picklee: T) {
-    def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
-    def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]
-    def pickleTo[S](output: S)(implicit format: PickleFormat): Unit = macro Compat.PickleMacros_pickleTo[T,S]
+    //def pickle(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType = 
+    //  scala.pickling.pickle(picklee)(format, pickler)
+    def pickle(implicit format: PickleFormat): format.PickleType = 
+      macro Compat.PickleMacros_pickle[T]
+    def pickleInto(builder: PBuilder)(implicit pickler: SPickler[T]): Unit = 
+      //macro Compat.PickleMacros_pickleInto[T]
+      scala.pickling.pickleInto(picklee, builder)(pickler)
+    def pickleTo[S](output: S)(implicit format: PickleFormat): Unit = 
+       macro Compat.PickleMacros_pickleTo[T,S]
   }
 
   implicit class UnpickleOps(val thePickle: Pickle) {
-    def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T = macro Compat.UnpickleMacros_pickleUnpickle[T]
+    def unpickle[T](implicit unpickler: Unpickler[T], format: PickleFormat): T = 
+    macro Compat.UnpickleMacros_pickleUnpickle[T]
   }
 
 }

--- a/core/src/main/scala/pickling/package.scala
+++ b/core/src/main/scala/pickling/package.scala
@@ -21,21 +21,36 @@ package object pickling {
   }
   def pickleInto[T](picklee: T, builder: PBuilder)(implicit pickler: SPickler[T]): Unit = {
   	// TODO - BeginEntry/EndEntry needed?
-  	pickler.pickle(picklee, builder)
+  	// TODO - this hinting should be in the pickler, not here.  We need to understand
+  	//        when we want to use this vs. something else.
+  	if(null == picklee) {
+  	  builder.hintTag(FastTypeTag.Null)
+  	  all.nullPicklerUnpickler.pickle(null, builder)
+  	} else {
+  	  builder.hintTag(pickler.tag)
+  	  pickler.pickle(picklee, builder)
+  	}
     // TODO - This usually doesn't clear Picklee's, but should we?
     // TODO - GRL Lock
   }
   def pickleTo[T, S](picklee: T, output: S)(implicit pickler: SPickler[T], format: PickleFormat): Unit = {
   	// SUPER HACK POWER TIME! - We should probably find a way of ensuring S <:< format.OutputType...
   	val builder = format.createBuilder(output.asInstanceOf[format.OutputType])
+
   	pickleInto(picklee, builder)
   	// TODO - some mechanism to turn this off
   	internal.clearPicklees()
   }
 
   implicit class PickleOps[T](picklee: T) {
-    def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
-    def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]
+
+    //def pickle(implicit format: PickleFormat): format.PickleType = macro Compat.PickleMacros_pickle[T]
+    def pickle(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType =
+      scala.pickling.pickle[T](picklee)(format, pickler)
+    // Note: TONS of macros in picklers use this, so we leave it as is...
+    //def pickleInto(builder: PBuilder): Unit = macro Compat.PickleMacros_pickleInto[T]
+    def pickleInto(builder: PBuilder)(implicit pickler: SPickler[T]): Unit =
+      scala.pickling.pickleInto(picklee, builder)(pickler)
     def pickleTo[S](output: S)(implicit format: PickleFormat): Unit = macro Compat.PickleMacros_pickleTo[T,S]
   }
 

--- a/core/src/main/scala/pickling/runtime/CustomRuntime.scala
+++ b/core/src/main/scala/pickling/runtime/CustomRuntime.scala
@@ -106,7 +106,7 @@ trait RuntimePicklersUnpicklers {
       builder.endEntry()
     }
 
-    def unpickle(tag: => FastTypeTag[_], preader: PReader): Any = {
+    def unpickle(tag: String, preader: PReader): Any = {
       val reader = preader.beginCollection()
 
       preader.pushHints()
@@ -123,9 +123,7 @@ trait RuntimePicklersUnpicklers {
       while (i < length) {
         try {
           val r = reader.readElement()
-          r.beginEntryNoTag()
-          val elem = elemUnpickler.unpickle(elemTag, r)
-          r.endEntry()
+          val elem = elemUnpickler.unpickleEntry(r)
           newArray(i) = elem.asInstanceOf[AnyRef]
           i = i + 1
         } catch {
@@ -203,7 +201,7 @@ class Tuple2RTPickler(tag: FastTypeTag[_]) extends SPickler[(Any, Any)] with Unp
           case PicklingException(msg, cause) =>
             throw PicklingException(s"""error in unpickle of '${this.getClass.getName}':
                                        |field name: '$name'
-                                       |field tag: '${tag1.key}'
+                                       |field tag: '${tag1}'
                                        |message:
                                        |$msg""".stripMargin, cause)
         }
@@ -213,7 +211,7 @@ class Tuple2RTPickler(tag: FastTypeTag[_]) extends SPickler[(Any, Any)] with Unp
     value
   }
 
-  def unpickle(tag: => FastTypeTag[_], reader: PReader): Any = {
+  def unpickle(tag: String, reader: PReader): Any = {
     val fld1 = unpickleField("_1", reader)
     val fld2 = unpickleField("_2", reader)
     (fld1, fld2)

--- a/core/src/main/scala/pickling/runtime/Runtime.scala
+++ b/core/src/main/scala/pickling/runtime/Runtime.scala
@@ -22,7 +22,6 @@ object Runtime {
 }
 
 import HasCompat._
-
 abstract class PicklerRuntime(classLoader: ClassLoader, preclazz: Class[_], share: refs.Share) {
   import scala.reflect.runtime.universe._
   import definitions._
@@ -68,6 +67,7 @@ class InterpretedPicklerRuntime(classLoader: ClassLoader, preclazz: Class[_])(im
   debug("InterpretedPicklerRuntime: preclazz = " + preclazz)
   debug("InterpretedPicklerRuntime: clazz    = " + clazz)
 
+  //  TODO - this pickler should know to lock the GRL before running itself, or any mirror code.
   def genPickler: SPickler[_] = {
     // build "interpreted" runtime pickler
     new SPickler[Any] with PickleTools {
@@ -174,6 +174,7 @@ class InterpretedUnpicklerRuntime(mirror: Mirror, typeTag: String)(implicit shar
   def shouldBotherAboutSharing(tpe: Type) = shareAnalyzer.shouldBotherAboutSharing(tpe)
   def shouldBotherAboutLooping(tpe: Type) = shareAnalyzer.shouldBotherAboutLooping(tpe)
 
+  // TODO - This method should lock the GRL before running any unpickle logic.
   def genUnpickler: Unpickler[Any] = {
     new Unpickler[Any] with PickleTools {
       def tag: FastTypeTag[Any] = fastTag.asInstanceOf[FastTypeTag[Any]]
@@ -273,6 +274,7 @@ class ShareNothingInterpretedUnpicklerRuntime(mirror: Mirror, typeTag: String)(i
   val cir = newClassIR(tpe)
   // debug("UnpicklerRuntime: cir = " + cir)
 
+  // TODO - This method should lock the GRL before running any unpickle logic
   def genUnpickler: Unpickler[Any] = {
     new Unpickler[Any] with PickleTools {
       def tag: FastTypeTag[Any] = fastTag.asInstanceOf[FastTypeTag[Any]]

--- a/core/src/main/scala/pickling/runtime/RuntimePickler.scala
+++ b/core/src/main/scala/pickling/runtime/RuntimePickler.scala
@@ -200,6 +200,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
 
       def tag: FastTypeTag[Any] = fastTag.asInstanceOf[FastTypeTag[Any]]
 
+      // TODO - We should use the GRL here
       def pickle(picklee: Any, builder: PBuilder): Unit = {
         //debug(s"pickling object of type: ${tag.key}")
         builder.beginEntry(picklee)

--- a/core/src/main/scala/pickling/runtime/RuntimePicklerLookup.scala
+++ b/core/src/main/scala/pickling/runtime/RuntimePicklerLookup.scala
@@ -5,6 +5,7 @@ import scala.reflect.runtime.{universe => ru}
 
 
 object RuntimePicklerLookup extends RuntimePicklersUnpicklers {
+  // TODO - We should lock the GRL before running this method, in case we generate any picklers.
   def genPickler(classLoader: ClassLoader, clazz: Class[_], tag: FastTypeTag[_])(implicit share: refs.Share): SPickler[_] = {
     // println(s"generating runtime pickler for $clazz") // NOTE: needs to be an explicit println, so that we don't occasionally fallback to runtime in static cases
     val className = if (clazz == null) "null" else clazz.getName

--- a/core/src/main/scala/pickling/runtime/RuntimeUnpicklerLookup.scala
+++ b/core/src/main/scala/pickling/runtime/RuntimeUnpicklerLookup.scala
@@ -8,7 +8,7 @@ import internal.Classes
 object RuntimeUnpicklerLookup extends RuntimePicklersUnpicklers {
   // Note: parameter `tag` may be `null`.
   // TODO - This method is one which would need the GRL, if we try to avoid using it in every
-  //        pickle/unpickle scenario.
+  //        unpickle scenario.
   def genUnpickler(mirror: Mirror, tagKey: String)(implicit share: refs.Share): Unpickler[_] = {
     // println(s"generating runtime unpickler for ${tagKey}") // NOTE: needs to be an explicit println, so that we don't occasionally fallback to runtime in static cases
     GlobalRegistry.unpicklerMap.get(tagKey) match {

--- a/core/src/test/scala/pickling/run/binary-list-int-custom-pickler-implicitly-selection.scala
+++ b/core/src/test/scala/pickling/run/binary-list-int-custom-pickler-implicitly-selection.scala
@@ -34,7 +34,7 @@ class BinaryListIntCustomTest extends FunSuite {
         builder.endCollection()
         builder.endEntry()
       }
-      def unpickle(tag: => FastTypeTag[_], reader: PReader): Any = {
+      def unpickle(tag: String, reader: PReader): Any = {
         val arrReader = reader.beginCollection()
         arrReader.hintStaticallyElidedType()
         arrReader.hintTag(FastTypeTag.Int)

--- a/core/src/test/scala/pickling/run/combinator-pickleinto.scala
+++ b/core/src/test/scala/pickling/run/combinator-pickleinto.scala
@@ -56,7 +56,7 @@ class CombinatorPickleIntoTest extends FunSuite {
     implicit def personup(implicit intup: Unpickler[Int]): Unpickler[Person] =
       new Unpickler[Person] {
         def tag: FastTypeTag[Person] = implicitly[FastTypeTag[Person]]
-        def unpickle(tag: => FastTypeTag[_], reader: PReader): Any = {
+        def unpickle(tag: String, reader: PReader): Any = {
           reader.hintTag(FastTypeTag.Int)
           reader.hintStaticallyElidedType()
           val tag = reader.beginEntry()

--- a/core/src/test/scala/pickling/run/custom-generic-pickler.scala
+++ b/core/src/test/scala/pickling/run/custom-generic-pickler.scala
@@ -33,7 +33,7 @@ class MyClassPickler[A](implicit val format: PickleFormat, aTypeTag: FastTypeTag
     builder.endEntry()
   }
 
-  override def unpickle(tag: => FastTypeTag[_], reader: PReader): MyClass[A] = {
+  override def unpickle(tagKey: String, reader: PReader): MyClass[A] = {
     reader.hintTag(FastTypeTag.String)
     val tag = reader.beginEntry()
 	  val myStringUnpickled = stringUnpickler.unpickle(tag, reader).asInstanceOf[String]

--- a/core/src/test/scala/pickling/run/static-only-with-manual-pickler.scala
+++ b/core/src/test/scala/pickling/run/static-only-with-manual-pickler.scala
@@ -20,7 +20,7 @@ class StaticOnlyWithManualPicklerTest extends FunSuite {
     implicit val picklerUnpickler: SPickler[NotClosed] with Unpickler[NotClosed] = new SPickler[NotClosed] with Unpickler[NotClosed] {
       def pickle(picklee: NotClosed, builder: PBuilder): Unit =
         throw FakeImplementation()
-      def unpickle(tag: => FastTypeTag[_], reader: PReader): Any =
+      def unpickle(tag: String, reader: PReader): Any =
         throw FakeImplementation()
       def tag = FastTypeTag[NotClosed]
     }

--- a/core/src/test/scala/pickling/run/static-only.scala
+++ b/core/src/test/scala/pickling/run/static-only.scala
@@ -39,4 +39,9 @@ class StaticOnlyTest extends FunSuite {
     val pickle: JSONPickle = x.pickle
     assert(pickle.unpickle[C].fld == 1)
   }
+  test("static-methods") {
+  	val x: C = new D
+    val pickle: JSONPickle = scala.pickling.pickle(x)
+    assert(unpickle[C](pickle).fld == 1)
+  }
 }

--- a/core/src/test/scala/pickling/run/wrapped-array.scala
+++ b/core/src/test/scala/pickling/run/wrapped-array.scala
@@ -43,7 +43,7 @@ class WrappedArrayTest extends FunSuite {
       builder.endEntry()
     }
 
-    def unpickle(tpe: => FastTypeTag[_], preader: PReader): Any = {
+    def unpickle(tpe: String, preader: PReader): Any = {
       val reader = preader.beginCollection()
 
       val length = reader.readLength()


### PR DESCRIPTION
This PR is a bit of dozy, so I'll follow up with what it does in tidbits.
- Remove `FastTypeTag[_]`, `mirror` from `PReader` and `PickleFormat` interfaces.   This limits reflective use to `SPickler`/`DPickler` and `Unpickler` instances, mostly.
  - Consolidate `beginEntry()` on `PReader` to one method which returns the string-y type.
  - Remove mirror var from all formats (json/binary)
  - Update all macros to call `internal.currentMirror` when they need a mirror from which to do reflection.
- Create vanilla methods for core pickle/unpickle logic.  Macros still generate SPickler/DPickler/Unpickler instances.
  - Create static methods in the package object which are the raw forms of `pickle`, `pickleInto`, `pickleTo` and `unpickle` extension methods.
  - Remote `pickle`, `pickleInto` and `unpickle` macros
  - Fix type limitation in AllPicklers.genPickler relating to module types.
- Document PBuilder/PReader semantics for implementers of PickleFormat.  Attempt to document enough of SPickler/Unpickler so that hand-written impelmentation can do the right thing.
- Add comments/plans for how to reduce the scope of GRL locking/unlocking so that it's only used when necessary (dynamic/reflective picklers), vs. for every pickler.

Locally I have all tests passing.  I realize the is a breaking change for implementers of SPickler/Unpickler and PickleFormat.   I think the gains are worth it, but it definitely needs to be in something that bumps the major version number (0.10.x hasn't had a release, but I'd understand if some of this waits for a 0.11.x or even gets pushed back).

I'm available via G+ hangout if you'd like to talk through the changes, as I realize it's a lot.
