### PR TITLE
ignore type tag when unpickling concrete types

### DIFF
--- a/core/src/main/scala/pickling/Macros.scala
+++ b/core/src/main/scala/pickling/Macros.scala
@@ -218,7 +218,7 @@ trait PicklerMacros extends Macro with PickleMacros with FastTypeTagMacros {
 
     def genDispatch(compileTimeDispatchees: List[Type], finalCases: List[CaseDef]): Tree = {
       val clazzName = newTermName("clazz")
-      val compileTimeDispatch = compileTimeDispatchees filter (_ != NullTpe) map { subtpe =>
+      val compileTimeDispatch = compileTimeDispatchees map { subtpe =>
         CaseDef(Bind(clazzName, Ident(nme.WILDCARD)), q"clazz == classOf[$subtpe]", createPickler(subtpe, q"builder"))
       }
       q"""

--- a/core/src/main/scala/pickling/Tools.scala
+++ b/core/src/main/scala/pickling/Tools.scala
@@ -334,6 +334,16 @@ abstract class Macro extends RichTypes { self =>
 
   def compileTimeDispatchees(tpe: Type): List[Type] = tools.compileTimeDispatchees(tpe, rootMirror)
 
+  def compileTimeDispatcheesNotEmpty(tpe: Type): List[Type] = {
+    val dispatchees = compileTimeDispatchees(tpe)
+    // this will catch at compile time a total failure of
+    // knownDirectSubclasses to find subtypes, though it won't
+    // catch a partial failure of knownDirectSubclasses
+    if (dispatchees.isEmpty)
+      throw new Exception(s"Didn't find any concrete subtypes of abstract $tpe, this may mean you need to use the @directSubclasses annotation to manually tell the compiler about subtypes")
+    dispatchees
+  }
+
   def syntheticPackageName: String = "scala.pickling.synthetic"
   def syntheticBaseName(tpe: Type): TypeName = {
     val raw = tpe.key.split('.').map(_.capitalize).mkString("")

--- a/core/src/main/scala/pickling/Tools.scala
+++ b/core/src/main/scala/pickling/Tools.scala
@@ -83,11 +83,9 @@ class Tools[C <: Context](val c: C) {
   }
 
   def compileTimeDispatchees(tpe: Type, mirror: Mirror): List[Type] = {
-    // TODO: why do we need nullTpe?
-    val nullTpe = if (tpe.baseClasses.contains(ObjectClass)) List(NullTpe) else Nil
     val subtypes = allStaticallyKnownConcreteSubclasses(tpe, mirror).filter(subtpe => subtpe.typeSymbol != tpe.typeSymbol)
     val selfTpe = if (isRelevantSubclass(tpe.typeSymbol, tpe.typeSymbol)) List(tpe) else Nil
-    val result = nullTpe ++ subtypes ++ selfTpe
+    val result = subtypes ++ selfTpe
     // println(s"$tpe => $result")
     result
   }

--- a/core/src/main/scala/pickling/json/JSONPickleFormat.scala
+++ b/core/src/main/scala/pickling/json/JSONPickleFormat.scala
@@ -242,7 +242,7 @@ package json {
     def atObject: Boolean = datum.isInstanceOf[JSONObject]
     def readField(name: String): JSONPickleReader = {
       datum match {
-        case JSONObject(fields) => mkNestedReader(fields(name))
+        case JSONObject(fields) => mkNestedReader(fields.get(name).getOrElse(throw PicklingException(s"No field '$name' when unpickling, tag $lastReadTag, fields were $fields")))
       }
     }
     def endEntry(): Unit = {}

--- a/core/src/test/scala/pickling/run/static-only-with-manual-pickler.scala
+++ b/core/src/test/scala/pickling/run/static-only-with-manual-pickler.scala
@@ -43,8 +43,10 @@ class StaticOnlyWithManualPicklerTest extends FunSuite {
   // Test that you can generate SPickler without having ops._ imported on the callsite.
   test ("manually generated pickler") {
     import scala.pickling.Defaults.intPickler
+    import scala.pickling.Defaults.refPickler
+    import scala.pickling.Defaults.refUnpickler
     implicit val applePickler: SPickler[Apple] = SPickler.generate[Apple]
-    implicit val appleUnpciker: Unpickler[Apple] = Unpickler.generate[Apple]
+    implicit val appleUnpickler: Unpickler[Apple] = Unpickler.generate[Apple]
     val pkl: JSONPickle = pickle(Apple(1))
   }
 }


### PR DESCRIPTION
There are some sort of vaguely-related cleanups in here, see the individual commit messages.
- removed Null from compileTimeDispatchees
- throw an exception if we have an empty dispatch (like attempting to pickle "sealed trait Foo" with no subtypes) to detect directKnownSubclasses problems
- improve "missing field" exception from JSON unpickler to give more info  
- if StaticOnly is imported fail unpickler generation at compile time rather than runtime
- improve error message when we can't generate an unpickler for an unclosed type due to StaticOnly
- improve error message when we can't generate an unpickler for an abstract type due to it not being closed
- use the refUnpickler in scope rather than a hardcoded one
