### PR TITLE
Rename SPickler to just Pickler

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ import scala.pickling.Defaults.{ stringPickler, intPickler, refUnpickler, nullPi
 
 case class Pumpkin(kind: String)
 // Manually generate a pickler using macro
-implicit val pumpkinPickler = SPickler.generate[Pumpkin]
+implicit val pumpkinPickler = Pickler.generate[Pumpkin]
 implicit val pumpkinUnpickler = Unpickler.generate[Pumpkin]
 
 val pckl = Pumpkin("Kabocha").pickle
@@ -119,11 +119,11 @@ defined class Pumpkin
 
 scala> val pumpkinJsonProtocol = new scala.pickling.pickler.PrimitivePicklers with
      |   scala.pickling.json.JsonFormats with scala.pickling.Ops {
-     |     import scala.pickling.{ SPickler, Unpickler }
-     |     implicit val pumpkinPickler = SPickler.generate[Pumpkin]
+     |     import scala.pickling.{ Pickler, Unpickler }
+     |     implicit val pumpkinPickler = Pickler.generate[Pumpkin]
      |     implicit val pumpkinUnpickler = Unpickler.generate[Pumpkin]
      |   }
-pumpkinJsonProtocol: scala.pickling.pickler.PrimitivePicklers with scala.pickling.json.JsonFormats with scala.pickling.Ops{implicit val pumpkinPickler: scala.pickling.SPickler[Pumpkin] with scala.pickling.Generated; implicit val pumpkinUnpickler: scala.pickling.Unpickler[Pumpkin] with scala.pickling.Generated} = $anon$1@500cd8e3
+pumpkinJsonProtocol: scala.pickling.pickler.PrimitivePicklers with scala.pickling.json.JsonFormats with scala.pickling.Ops{implicit val pumpkinPickler: scala.pickling.Pickler[Pumpkin] with scala.pickling.Generated; implicit val pumpkinUnpickler: scala.pickling.Unpickler[Pumpkin] with scala.pickling.Generated} = $anon$1@500cd8e3
 ```
 
 Now your library user can import `pumpkinJsonProtocol` as follows:

--- a/benchmark/Evactor.scala
+++ b/benchmark/Evactor.scala
@@ -30,9 +30,9 @@ object EvactorPicklingBench extends scala.pickling.testing.PicklingBenchmark {
     val tagOfInt = "boom!"
     implicitly[FastTypeTag[Int]]
   }
-  implicit lazy val picklerOfDataEvent: SPickler[DataEvent] = {
+  implicit lazy val picklerOfDataEvent: Pickler[DataEvent] = {
     val picklerOfDataEvent = "boom!"
-    implicitly[SPickler[DataEvent]]
+    implicitly[Pickler[DataEvent]]
   }
   implicit lazy val unpicklerOfDataEvent: Unpickler[DataEvent] = {
     val unpicklerOfDataEvent = "boom!"

--- a/benchmark/WikiGraph.scala
+++ b/benchmark/WikiGraph.scala
@@ -169,16 +169,16 @@ object WikiGraphPicklingBench extends WikiGraphBenchmark {
   // TODO - why does this no longer compile?
   implicit val picklerNil = DPickler.genDPickler[Nil.type] 
   implicit val unpicklerNil = implicitly[Unpickler[Nil.type]]
-  implicit lazy val picklerVertex: SPickler[Vertex] = {
+  implicit lazy val picklerVertex: Pickler[Vertex] = {
     val picklerVertex = "boom!"
-    implicitly[SPickler[Vertex]]
+    implicitly[Pickler[Vertex]]
   }
   implicit lazy val unpicklerVertex: Unpickler[Vertex] = {
     val unpicklerVertex = "boom!"
     implicitly[Unpickler[Vertex]]
   }
   // NOTE: doesn't work well either
-  // implicit object PicklerUnpicklerColonColonVertex extends scala.pickling.SPickler[::[Vertex]] with scala.pickling.Unpickler[::[Vertex]] {
+  // implicit object PicklerUnpicklerColonColonVertex extends scala.pickling.Pickler[::[Vertex]] with scala.pickling.Unpickler[::[Vertex]] {
   //   import scala.reflect.runtime.universe._
   //   import scala.pickling._
   //   import scala.pickling.`package`.PickleOps
@@ -222,9 +222,9 @@ object WikiGraphPicklingBench extends WikiGraphBenchmark {
   //     }
   //   }
   // }
-  implicit lazy val picklerUnpicklerColonColonVertex: SPickler[::[Vertex]] with Unpickler[::[Vertex]] = implicitly
-  implicit lazy val picklerUnpicklerVectorVertex: SPickler[Vector[Vertex]] with Unpickler[Vector[Vertex]] = all.vectorPickler[Vertex]
-  implicit val picklerGraph = implicitly[SPickler[Graph]]
+  implicit lazy val picklerUnpicklerColonColonVertex: Pickler[::[Vertex]] with Unpickler[::[Vertex]] = implicitly
+  implicit lazy val picklerUnpicklerVectorVertex: Pickler[Vector[Vertex]] with Unpickler[Vector[Vertex]] = all.vectorPickler[Vertex]
+  implicit val picklerGraph = implicitly[Pickler[Graph]]
   implicit val unpicklerGraph = implicitly[Unpickler[Graph]]
 
   override def run(): Unit = {

--- a/core/src/main/scala/pickling/Compat.scala
+++ b/core/src/main/scala/pickling/Compat.scala
@@ -14,10 +14,10 @@ object Compat {
     def pt: A = t._1
   }
 
-  def PicklerMacros_impl[T: c.WeakTypeTag](c: Context): c.Expr[SPickler[T]] = {
+  def PicklerMacros_impl[T: c.WeakTypeTag](c: Context): c.Expr[Pickler[T]] = {
     val c0: c.type = c
     val bundle = new { val c: c0.type = c0 } with PicklerMacros
-    c.Expr[SPickler[T]](bundle.impl[T])
+    c.Expr[Pickler[T]](bundle.impl[T])
   }
 
   def UnpicklerMacros_impl[T: c.WeakTypeTag](c: Context): c.Expr[Unpickler[T] with Generated] = {
@@ -26,10 +26,10 @@ object Compat {
     c.Expr[Unpickler[T] with Generated](bundle.impl[T])
   }
 
-  def SpicklerUnpicklerMacros_impl[T: c.WeakTypeTag](c: Context): c.Expr[SPickler[T] with Unpickler[T]] = {
+  def PicklerUnpicklerMacros_impl[T: c.WeakTypeTag](c: Context): c.Expr[Pickler[T] with Unpickler[T]] = {
     val c0: c.type = c
     val bundle = new { val c: c0.type = c0 } with PicklerUnpicklerMacros
-    c.Expr[SPickler[T] with Unpickler[T]](bundle.impl[T])
+    c.Expr[Pickler[T] with Unpickler[T]](bundle.impl[T])
   }
 
   def OpenSumUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context): c.Expr[Unpickler[T] with Generated] = {
@@ -44,10 +44,10 @@ object Compat {
     c.Expr[Unit](bundle.pickleTo[T](output.tree)(format.tree))
   }
 
-  def ListPicklerUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[SPickler[T] with Unpickler[T]] = {
+  def ListPicklerUnpicklerMacro_impl[T: c.WeakTypeTag](c: Context)(format: c.Expr[PickleFormat]): c.Expr[Pickler[T] with Unpickler[T]] = {
     val c0: c.type = c
     val bundle = new { val c: c0.type = c0 } with ListPicklerUnpicklerMacro
-    c.Expr[SPickler[T] with Unpickler[T]](bundle.impl[T](format.tree))
+    c.Expr[Pickler[T] with Unpickler[T]](bundle.impl[T](format.tree))
   }
 
   def PicklerMacros_dpicklerImpl[T: c.WeakTypeTag](c: Context): c.Expr[DPickler[T]] = {

--- a/core/src/main/scala/pickling/Macros.scala
+++ b/core/src/main/scala/pickling/Macros.scala
@@ -47,7 +47,7 @@ trait PicklerUnpicklerMacros extends Macro
     val createTagTree = super[FastTypeTagMacros].impl[T]
 
     q"""
-      implicit object $picklerUnpicklerName extends _root_.scala.pickling.SPickler[$tpe] with _root_.scala.pickling.Unpickler[$tpe] with _root_.scala.pickling.Generated
+      implicit object $picklerUnpicklerName extends _root_.scala.pickling.Pickler[$tpe] with _root_.scala.pickling.Unpickler[$tpe] with _root_.scala.pickling.Generated
       {
         import _root_.scala.language.existentials
         import _root_.scala.pickling._
@@ -292,8 +292,8 @@ trait PicklerMacros extends Macro with PickleMacros with FastTypeTagMacros {
       // do not abort, but generate dispatch
       case tpe1 if sym.isAbstractClass && isClosed(sym) =>
         q"""
-          val pickler: scala.pickling.SPickler[_] = $genClosedDispatch
-          pickler.asInstanceOf[scala.pickling.SPickler[$tpe1]].pickle(picklee, builder)
+          val pickler: scala.pickling.Pickler[_] = $genClosedDispatch
+          pickler.asInstanceOf[scala.pickling.Pickler[$tpe1]].pickle(picklee, builder)
         """
 
       case tpe1 if sym.isClass =>
@@ -308,8 +308,8 @@ trait PicklerMacros extends Macro with PickleMacros with FastTypeTagMacros {
             nonFinalDispatch(excludeSelf)
 
           q"""
-            val pickler: scala.pickling.SPickler[_] = $dispatchTree
-            pickler.asInstanceOf[scala.pickling.SPickler[$tpe1]].pickle(picklee, builder)
+            val pickler: scala.pickling.Pickler[_] = $dispatchTree
+            pickler.asInstanceOf[scala.pickling.Pickler[$tpe1]].pickle(picklee, builder)
           """
         }
 
@@ -336,7 +336,7 @@ trait PicklerMacros extends Macro with PickleMacros with FastTypeTagMacros {
     // Used to generate implicit object here
     q"""
       locally {
-        implicit object $picklerName extends scala.pickling.SPickler[$tpe] with scala.pickling.Generated {
+        implicit object $picklerName extends scala.pickling.Pickler[$tpe] with scala.pickling.Generated {
           import _root_.scala.pickling._
           import _root_.scala.pickling.internal._
           import _root_.scala.pickling.PickleOps
@@ -698,7 +698,7 @@ trait PickleMacros extends Macro with TypeAnalysis {
   }
 
   def createPickler(tpe: c.Type, builder: c.Tree): c.Tree = q"""
-    val pickler = implicitly[scala.pickling.SPickler[$tpe]]
+    val pickler = implicitly[scala.pickling.Pickler[$tpe]]
     $builder.hintTag(pickler.tag)
     pickler
   """
@@ -718,7 +718,7 @@ trait PickleMacros extends Macro with TypeAnalysis {
     """ else q"""
       if ($pickleeName != null) {
         val $picklerName = ${createPickler(tpe, builder)}
-        $picklerName.asInstanceOf[scala.pickling.SPickler[$tpe]].pickle($pickleeName, $builder)
+        $picklerName.asInstanceOf[scala.pickling.Pickler[$tpe]].pickle($pickleeName, $builder)
       } else {
         $builder.hintTag(scala.pickling.FastTypeTag.Null)
         scala.pickling.Defaults.nullPickler.pickle(null, $builder)

--- a/core/src/main/scala/pickling/Ops.scala
+++ b/core/src/main/scala/pickling/Ops.scala
@@ -5,15 +5,15 @@ import scala.language.implicitConversions
 
 /** Appends the pickle/pickleTo/pickleInto operations onto any type, assuming implicits picklers are available. */
 final case class PickleOps[T](picklee: T) {
-  def pickle(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType =
+  def pickle(implicit format: PickleFormat, pickler: Pickler[T]): format.PickleType =
     functions.pickle[T](picklee)(format, pickler)
-  def pickleInto(builder: PBuilder)(implicit pickler: SPickler[T]): Unit =
+  def pickleInto(builder: PBuilder)(implicit pickler: Pickler[T]): Unit =
     functions.pickleInto(picklee, builder)(pickler)
   // pickleTo remains a macro so further type-checking of [S <:< format.OutputType] occurs,
   // and any implicit conversions required for this.
   def pickleTo[S](output: S)(implicit format: PickleFormat): Unit =
     macro Compat.PickleMacros_pickleTo[T,S]
-  //def pickleTo[S](output: S)(implicit format: PickleFormat, pickler: SPickler[T]): Unit =
+  //def pickleTo[S](output: S)(implicit format: PickleFormat, pickler: Pickler[T]): Unit =
   //  functions.pickleTo(picklee, output)(pickler, format)
 }
 

--- a/core/src/main/scala/pickling/functions.scala
+++ b/core/src/main/scala/pickling/functions.scala
@@ -14,14 +14,14 @@ object functions {
       result
     } finally internal.GRL.unlock()
   }
-  def pickle[T](picklee: T)(implicit format: PickleFormat, pickler: SPickler[T]): format.PickleType = {
+  def pickle[T](picklee: T)(implicit format: PickleFormat, pickler: Pickler[T]): format.PickleType = {
     val builder = format.createBuilder
     pickleInto(picklee, builder)
     // TODO - some mechanism to disable this.
     internal.clearPicklees()
     builder.result.asInstanceOf[format.PickleType]
   }
-  def pickleInto[T](picklee: T, builder: PBuilder)(implicit pickler: SPickler[T]): Unit = {
+  def pickleInto[T](picklee: T, builder: PBuilder)(implicit pickler: Pickler[T]): Unit = {
     // TODO - BeginEntry/EndEntry needed?
     // TODO - this hinting should be in the pickler, not here.  We need to understand
     //        when we want to use this vs. something else.
@@ -39,7 +39,7 @@ object functions {
     // TODO - This usually doesn't clear Picklee's, but should we?
   }
 
-  def pickleTo[T, F <: PickleFormat](picklee: T, output: F#OutputType)(implicit pickler: SPickler[T], format: F): Unit = {
+  def pickleTo[T, F <: PickleFormat](picklee: T, output: F#OutputType)(implicit pickler: Pickler[T], format: F): Unit = {
     // Lesser HACK POWER TIME! - We should probably find a way of ensuring S <:< format.OutputType...
     val builder = format.createBuilder(output.asInstanceOf[format.OutputType])
     pickleInto(picklee, builder)

--- a/core/src/main/scala/pickling/pickler/Array.scala
+++ b/core/src/main/scala/pickling/pickler/Array.scala
@@ -4,7 +4,7 @@ package pickler
 import scala.collection.generic.CanBuildFrom
 
 trait ArrayPicklers {
-  implicit def arrayPickler[T >: Null: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+  implicit def arrayPickler[T >: Null: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[Array[T]], cbf: CanBuildFrom[Array[T], T, Array[T]]):
-    SPickler[Array[T]] with Unpickler[Array[T]] = TravPickler[T, Array[T]]
+    Pickler[Array[T]] with Unpickler[Array[T]] = TravPickler[T, Array[T]]
 }

--- a/core/src/main/scala/pickling/pickler/ArrayBuffer.scala
+++ b/core/src/main/scala/pickling/pickler/ArrayBuffer.scala
@@ -5,8 +5,8 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.ArrayBuffer
 
 trait ArrayBufferPicklers {
-  implicit def arrayBufferPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+  implicit def arrayBufferPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[ArrayBuffer[T]], cbf: CanBuildFrom[ArrayBuffer[T], T, ArrayBuffer[T]]):
-    SPickler[ArrayBuffer[T]] with Unpickler[ArrayBuffer[T]] =
+    Pickler[ArrayBuffer[T]] with Unpickler[ArrayBuffer[T]] =
     SeqSetPickler[T, ArrayBuffer]
 }

--- a/core/src/main/scala/pickling/pickler/Date.scala
+++ b/core/src/main/scala/pickling/pickler/Date.scala
@@ -5,8 +5,8 @@ import java.util.{Date, TimeZone}
 import java.text.SimpleDateFormat
 
 trait DatePicklers extends PrimitivePicklers {
-  implicit val datePickler: SPickler[Date] with Unpickler[Date] =
-  new SPickler[Date] with Unpickler[Date] {
+  implicit val datePickler: Pickler[Date] with Unpickler[Date] =
+  new Pickler[Date] with Unpickler[Date] {
     private val dateFormatTemplate = {
       val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") //use ISO_8601 format
       format.setLenient(false)

--- a/core/src/main/scala/pickling/pickler/GenPicklers.scala
+++ b/core/src/main/scala/pickling/pickler/GenPicklers.scala
@@ -3,9 +3,9 @@ package pickler
 
 import scala.language.experimental.macros
 
-/** Mix-in trait to generate `SPickler`s implicitly.
- * See also `SPickler.generate`.
+/** Mix-in trait to generate `Pickler`s implicitly.
+ * See also `Pickler.generate`.
  */
 trait GenPicklers {
-  implicit def genPickler[T]: SPickler[T] = macro Compat.PicklerMacros_impl[T]
+  implicit def genPickler[T]: Pickler[T] = macro Compat.PicklerMacros_impl[T]
 }

--- a/core/src/main/scala/pickling/pickler/Iterable.scala
+++ b/core/src/main/scala/pickling/pickler/Iterable.scala
@@ -6,16 +6,16 @@ import scala.collection.generic.CanBuildFrom
 import scala.language.higherKinds
 
 trait IterablePicklers {
-  implicit def iterablePickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+  implicit def iterablePickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[Iterable[T]], cbf: CanBuildFrom[Iterable[T], T, Iterable[T]]):
-    SPickler[Iterable[T]] with Unpickler[Iterable[T]] = TravPickler[T, Iterable[T]]
+    Pickler[Iterable[T]] with Unpickler[Iterable[T]] = TravPickler[T, Iterable[T]]
 }
 
 object TravPickler {
   def apply[T: FastTypeTag, C <% Traversable[_]]
-    (implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
-              cbf: CanBuildFrom[C, T, C], collTag: FastTypeTag[C]): SPickler[C] with Unpickler[C] =
-    new SPickler[C] with Unpickler[C] {
+    (implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
+              cbf: CanBuildFrom[C, T, C], collTag: FastTypeTag[C]): Pickler[C] with Unpickler[C] =
+    new Pickler[C] with Unpickler[C] {
 
     val elemTag  = implicitly[FastTypeTag[T]]
     val isPrimitive = elemTag.isEffectivelyPrimitive
@@ -77,16 +77,16 @@ object TravPickler {
 
 object SeqSetPickler {
   def apply[T: FastTypeTag, Coll[_] <: Traversable[_]]
-    (implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+    (implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
               cbf: CanBuildFrom[Coll[T], T, Coll[T]],
-              collTag: FastTypeTag[Coll[T]]): SPickler[Coll[T]] with Unpickler[Coll[T]] =
+              collTag: FastTypeTag[Coll[T]]): Pickler[Coll[T]] with Unpickler[Coll[T]] =
     TravPickler[T, Coll[T]]
 }
 
 object MapPickler {
   def apply[K: FastTypeTag, V: FastTypeTag, M[_, _] <: collection.Map[_, _]]
-    (implicit elemPickler: SPickler[(K, V)], elemUnpickler: Unpickler[(K, V)],
+    (implicit elemPickler: Pickler[(K, V)], elemUnpickler: Unpickler[(K, V)],
               cbf: CanBuildFrom[M[K, V], (K, V), M[K, V]],
-              pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[M[K, V]]): SPickler[M[K, V]] with Unpickler[M[K, V]] =
+              pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[M[K, V]]): Pickler[M[K, V]] with Unpickler[M[K, V]] =
     TravPickler[(K, V), M[K, V]]
 }

--- a/core/src/main/scala/pickling/pickler/JavaBigDecimal.scala
+++ b/core/src/main/scala/pickling/pickler/JavaBigDecimal.scala
@@ -8,7 +8,7 @@ import java.math.BigDecimal
   */
 trait JavaBigDecimalPicklers extends PrimitivePicklers {
   implicit val javaBigDecimalPickler:
-    SPickler[BigDecimal] with Unpickler[BigDecimal] = new SPickler[BigDecimal] with Unpickler[BigDecimal]{
+    Pickler[BigDecimal] with Unpickler[BigDecimal] = new Pickler[BigDecimal] with Unpickler[BigDecimal]{
     def tag = FastTypeTag[BigDecimal]
     def pickle(picklee: BigDecimal, builder: PBuilder): Unit = {
       builder.beginEntry(picklee)

--- a/core/src/main/scala/pickling/pickler/JavaBigInteger.scala
+++ b/core/src/main/scala/pickling/pickler/JavaBigInteger.scala
@@ -7,7 +7,7 @@ import java.math.BigInteger
 /** This contains implicits which can serialize java.math.BigInteger values. */
 trait JavaBigIntegerPicklers extends PrimitivePicklers {
   implicit val javaBigIntegerPickler:
-    SPickler[BigInteger] with Unpickler[BigInteger] = new SPickler[BigInteger] with Unpickler[BigInteger] {
+    Pickler[BigInteger] with Unpickler[BigInteger] = new Pickler[BigInteger] with Unpickler[BigInteger] {
     def tag = FastTypeTag[BigInteger]
     def pickle(picklee: BigInteger, builder: PBuilder): Unit = {
       builder.beginEntry(picklee)

--- a/core/src/main/scala/pickling/pickler/List.scala
+++ b/core/src/main/scala/pickling/pickler/List.scala
@@ -29,15 +29,15 @@ trait CollectionPicklerUnpicklerMacro extends Macro with UnpickleMacros {
     val isFinal = eltpe.isEffectivelyFinal
     val picklerUnpicklerName = c.fresh(syntheticPicklerUnpicklerName(tpe).toTermName)
     q"""
-      implicit object $picklerUnpicklerName extends scala.pickling.SPickler[$tpe] with scala.pickling.Unpickler[$tpe] {
+      implicit object $picklerUnpicklerName extends scala.pickling.Pickler[$tpe] with scala.pickling.Unpickler[$tpe] {
         import scala.reflect.runtime.universe._
         import scala.pickling._
         import scala.pickling.internal._
         import scala.pickling.PickleOps
 
-        val elpickler: SPickler[$eltpe] = {
+        val elpickler: Pickler[$eltpe] = {
           val elpickler = "bam!"
-          implicitly[SPickler[$eltpe]]
+          implicitly[Pickler[$eltpe]]
         }
         val elunpickler: Unpickler[$eltpe] = {
           val elunpickler = "bam!"

--- a/core/src/main/scala/pickling/pickler/Map.scala
+++ b/core/src/main/scala/pickling/pickler/Map.scala
@@ -5,16 +5,16 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.{ immutable, mutable }
 
 trait MapPicklers {
-  implicit def mapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: SPickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[Map[K, V]], cbf: CanBuildFrom[Map[K, V], (K, V), Map[K, V]]): SPickler[Map[K, V]] with Unpickler[Map[K, V]] =
+  implicit def mapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: Pickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[Map[K, V]], cbf: CanBuildFrom[Map[K, V], (K, V), Map[K, V]]): Pickler[Map[K, V]] with Unpickler[Map[K, V]] =
     MapPickler[K, V, Map]
 }
 
 trait ImmutableSortedMapPicklers {
-  implicit def immutableSortedMapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: SPickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[immutable.SortedMap[K, V]], cbf: CanBuildFrom[immutable.SortedMap[K, V], (K, V), immutable.SortedMap[K, V]]): SPickler[immutable.SortedMap[K, V]] with Unpickler[immutable.SortedMap[K, V]] =
+  implicit def immutableSortedMapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: Pickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[immutable.SortedMap[K, V]], cbf: CanBuildFrom[immutable.SortedMap[K, V], (K, V), immutable.SortedMap[K, V]]): Pickler[immutable.SortedMap[K, V]] with Unpickler[immutable.SortedMap[K, V]] =
     MapPickler[K, V, immutable.SortedMap]
 }
 
 trait MutableMapPicklers {
-  implicit def mutableMapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: SPickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[mutable.Map[K, V]], cbf: CanBuildFrom[mutable.Map[K, V], (K, V), mutable.Map[K, V]]): SPickler[mutable.Map[K, V]] with Unpickler[mutable.Map[K, V]] =
+  implicit def mutableMapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: Pickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[mutable.Map[K, V]], cbf: CanBuildFrom[mutable.Map[K, V], (K, V), mutable.Map[K, V]]): Pickler[mutable.Map[K, V]] with Unpickler[mutable.Map[K, V]] =
     MapPickler[K, V, mutable.Map]
 }

--- a/core/src/main/scala/pickling/pickler/PrimitiveArrays.scala
+++ b/core/src/main/scala/pickling/pickler/PrimitiveArrays.scala
@@ -4,12 +4,12 @@ package pickler
 /** Picklers for primitive arrays.
  */
 trait PrimitiveArrayPicklers {
-  implicit val byteArrayPickler: SPickler[Array[Byte]] with Unpickler[Array[Byte]] = PrimitivePickler[Array[Byte]]
-  implicit val shortArrayPickler: SPickler[Array[Short]] with Unpickler[Array[Short]] = PrimitivePickler[Array[Short]]
-  implicit val charArrayPickler: SPickler[Array[Char]] with Unpickler[Array[Char]] = PrimitivePickler[Array[Char]]
-  implicit val intArrayPickler: SPickler[Array[Int]] with Unpickler[Array[Int]] = PrimitivePickler[Array[Int]]
-  implicit val longArrayPickler: SPickler[Array[Long]] with Unpickler[Array[Long]] = PrimitivePickler[Array[Long]]
-  implicit val booleanArrayPickler: SPickler[Array[Boolean]] with Unpickler[Array[Boolean]] = PrimitivePickler[Array[Boolean]]
-  implicit val floatArrayPickler: SPickler[Array[Float]] with Unpickler[Array[Float]] = PrimitivePickler[Array[Float]]
-  implicit val doubleArrayPickler: SPickler[Array[Double]] with Unpickler[Array[Double]] = PrimitivePickler[Array[Double]]
+  implicit val byteArrayPickler: Pickler[Array[Byte]] with Unpickler[Array[Byte]] = PrimitivePickler[Array[Byte]]
+  implicit val shortArrayPickler: Pickler[Array[Short]] with Unpickler[Array[Short]] = PrimitivePickler[Array[Short]]
+  implicit val charArrayPickler: Pickler[Array[Char]] with Unpickler[Array[Char]] = PrimitivePickler[Array[Char]]
+  implicit val intArrayPickler: Pickler[Array[Int]] with Unpickler[Array[Int]] = PrimitivePickler[Array[Int]]
+  implicit val longArrayPickler: Pickler[Array[Long]] with Unpickler[Array[Long]] = PrimitivePickler[Array[Long]]
+  implicit val booleanArrayPickler: Pickler[Array[Boolean]] with Unpickler[Array[Boolean]] = PrimitivePickler[Array[Boolean]]
+  implicit val floatArrayPickler: Pickler[Array[Float]] with Unpickler[Array[Float]] = PrimitivePickler[Array[Float]]
+  implicit val doubleArrayPickler: Pickler[Array[Double]] with Unpickler[Array[Double]] = PrimitivePickler[Array[Double]]
 }

--- a/core/src/main/scala/pickling/pickler/Primitives.scala
+++ b/core/src/main/scala/pickling/pickler/Primitives.scala
@@ -5,17 +5,17 @@ package pickler
  */
 trait PrimitivePicklers {
   // TODO: figure out why removing these pickler/unpicklers slows down evactor1
-  implicit val bytePickler: SPickler[Byte] with Unpickler[Byte] = PrimitivePickler[Byte]
-  implicit val shortPickler: SPickler[Short] with Unpickler[Short] = PrimitivePickler[Short]
-  implicit val charPickler: SPickler[Char] with Unpickler[Char] = PrimitivePickler[Char]
-  implicit val intPickler: SPickler[Int] with Unpickler[Int] = PrimitivePickler[Int]
-  implicit val longPickler: SPickler[Long] with Unpickler[Long] = PrimitivePickler[Long]
-  implicit val booleanPickler: SPickler[Boolean] with Unpickler[Boolean] = PrimitivePickler[Boolean]
-  implicit val floatPickler: SPickler[Float] with Unpickler[Float] = PrimitivePickler[Float]
-  implicit val doublePickler: SPickler[Double] with Unpickler[Double] = PrimitivePickler[Double]
-  implicit val nullPickler: SPickler[Null] with Unpickler[Null] = PrimitivePickler[Null]
-  implicit val stringPickler: SPickler[String] with Unpickler[String] = PrimitivePickler[String]
-  implicit val unitPickler: SPickler[Unit] with Unpickler[Unit] = PrimitivePickler[Unit]
+  implicit val bytePickler: Pickler[Byte] with Unpickler[Byte] = PrimitivePickler[Byte]
+  implicit val shortPickler: Pickler[Short] with Unpickler[Short] = PrimitivePickler[Short]
+  implicit val charPickler: Pickler[Char] with Unpickler[Char] = PrimitivePickler[Char]
+  implicit val intPickler: Pickler[Int] with Unpickler[Int] = PrimitivePickler[Int]
+  implicit val longPickler: Pickler[Long] with Unpickler[Long] = PrimitivePickler[Long]
+  implicit val booleanPickler: Pickler[Boolean] with Unpickler[Boolean] = PrimitivePickler[Boolean]
+  implicit val floatPickler: Pickler[Float] with Unpickler[Float] = PrimitivePickler[Float]
+  implicit val doublePickler: Pickler[Double] with Unpickler[Double] = PrimitivePickler[Double]
+  implicit val nullPickler: Pickler[Null] with Unpickler[Null] = PrimitivePickler[Null]
+  implicit val stringPickler: Pickler[String] with Unpickler[String] = PrimitivePickler[String]
+  implicit val unitPickler: Pickler[Unit] with Unpickler[Unit] = PrimitivePickler[Unit]
 }
 
 class PrimitivePickler[T: FastTypeTag](name: String) extends AutoRegister[T](name) {
@@ -36,6 +36,6 @@ class PrimitivePickler[T: FastTypeTag](name: String) extends AutoRegister[T](nam
   }
 }
 object PrimitivePickler {
-  def apply[A: FastTypeTag]: SPickler[A] with Unpickler[A] =
+  def apply[A: FastTypeTag]: Pickler[A] with Unpickler[A] =
     new PrimitivePickler[A](FastTypeTag.valueTypeName(implicitly[FastTypeTag[A]]))
 }

--- a/core/src/main/scala/pickling/pickler/Ref.scala
+++ b/core/src/main/scala/pickling/pickler/Ref.scala
@@ -2,6 +2,6 @@ package scala.pickling
 package pickler
 
 trait RefPicklers {
-  implicit def refPickler: SPickler[refs.Ref] = throw new Error("cannot pickle refs") // TODO: make this a macro
+  implicit def refPickler: Pickler[refs.Ref] = throw new Error("cannot pickle refs") // TODO: make this a macro
   implicit val refUnpickler: Unpickler[refs.Ref] = PrimitivePickler[refs.Ref]
 }

--- a/core/src/main/scala/pickling/pickler/Seq.scala
+++ b/core/src/main/scala/pickling/pickler/Seq.scala
@@ -5,21 +5,21 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.{ IndexedSeq, LinearSeq }
 
 trait SeqPicklers {
-  implicit def seqPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
-    collTag: FastTypeTag[Seq[T]], cbf: CanBuildFrom[Seq[T], T, Seq[T]]): SPickler[Seq[T]] with Unpickler[Seq[T]] =
+  implicit def seqPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
+    collTag: FastTypeTag[Seq[T]], cbf: CanBuildFrom[Seq[T], T, Seq[T]]): Pickler[Seq[T]] with Unpickler[Seq[T]] =
     SeqSetPickler[T, Seq]
 }
 
 trait IndexedSeqPicklers {
-  implicit def indexedSeqPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+  implicit def indexedSeqPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[IndexedSeq[T]], cbf: CanBuildFrom[IndexedSeq[T], T, IndexedSeq[T]]):
-    SPickler[IndexedSeq[T]] with Unpickler[IndexedSeq[T]] =
+    Pickler[IndexedSeq[T]] with Unpickler[IndexedSeq[T]] =
     SeqSetPickler[T, IndexedSeq]
 }
 
 trait LinearSeqPicklers {
-  implicit def linearSeqPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+  implicit def linearSeqPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[LinearSeq[T]], cbf: CanBuildFrom[LinearSeq[T], T, LinearSeq[T]]):
-    SPickler[LinearSeq[T]] with Unpickler[LinearSeq[T]] =
+    Pickler[LinearSeq[T]] with Unpickler[LinearSeq[T]] =
     SeqSetPickler[T, LinearSeq]
 }

--- a/core/src/main/scala/pickling/pickler/Set.scala
+++ b/core/src/main/scala/pickling/pickler/Set.scala
@@ -5,28 +5,28 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.{ immutable, mutable }
 
 trait SetPicklers {
-  implicit def setPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
-    collTag: FastTypeTag[Set[T]], cbf: CanBuildFrom[Set[T], T, Set[T]]): SPickler[Set[T]] with Unpickler[Set[T]] =
+  implicit def setPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
+    collTag: FastTypeTag[Set[T]], cbf: CanBuildFrom[Set[T], T, Set[T]]): Pickler[Set[T]] with Unpickler[Set[T]] =
     SeqSetPickler[T, Set]
 }
 
 trait ImmutableSortedSetPicklers {
-  implicit def immutableSortedSetPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+  implicit def immutableSortedSetPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[immutable.SortedSet[T]], cbf: CanBuildFrom[immutable.SortedSet[T], T, immutable.SortedSet[T]]):
-    SPickler[immutable.SortedSet[T]] with Unpickler[immutable.SortedSet[T]] =
+    Pickler[immutable.SortedSet[T]] with Unpickler[immutable.SortedSet[T]] =
     SeqSetPickler[T, immutable.SortedSet]
 }
 
 trait MutableSetPicklers {
-  implicit def mutableSetPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+  implicit def mutableSetPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[mutable.Set[T]], cbf: CanBuildFrom[mutable.Set[T], T, mutable.Set[T]]):
-    SPickler[mutable.Set[T]] with Unpickler[mutable.Set[T]] =
+    Pickler[mutable.Set[T]] with Unpickler[mutable.Set[T]] =
     SeqSetPickler[T, mutable.Set]
 }
 
 trait MutableSortedSetPicklers {
-  implicit def mutableSortedSetPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T],
+  implicit def mutableSortedSetPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[mutable.SortedSet[T]], cbf: CanBuildFrom[mutable.SortedSet[T], T, mutable.SortedSet[T]]):
-    SPickler[mutable.SortedSet[T]] with Unpickler[mutable.SortedSet[T]] =
+    Pickler[mutable.SortedSet[T]] with Unpickler[mutable.SortedSet[T]] =
     SeqSetPickler[T, mutable.SortedSet]
 }

--- a/core/src/main/scala/pickling/pickler/Vector.scala
+++ b/core/src/main/scala/pickling/pickler/Vector.scala
@@ -4,8 +4,8 @@ package pickler
 import scala.collection.generic.CanBuildFrom
 
 trait VectorPicklers {
-  implicit def vectorPickler[T: FastTypeTag](implicit elemPickler: SPickler[T],
+  implicit def vectorPickler[T: FastTypeTag](implicit elemPickler: Pickler[T],
     elemUnpickler: Unpickler[T], collTag: FastTypeTag[Vector[T]], cbf: CanBuildFrom[Vector[T], T, Vector[T]]):
-    SPickler[Vector[T]] with Unpickler[Vector[T]] =
+    Pickler[Vector[T]] with Unpickler[Vector[T]] =
     SeqSetPickler[T, Vector]
 }

--- a/core/src/main/scala/pickling/runtime/CustomRuntime.scala
+++ b/core/src/main/scala/pickling/runtime/CustomRuntime.scala
@@ -73,10 +73,10 @@ trait RuntimePicklersUnpicklers {
 
 
   def mkRuntimeTravPickler[C <% Traversable[_]](elemClass: Class[_], elemTag: FastTypeTag[_], collTag: FastTypeTag[_],
-                                                elemPickler0: SPickler[_], elemUnpickler0: Unpickler[_]):
-    SPickler[C] with Unpickler[C] = new SPickler[C] with Unpickler[C] {
+                                                elemPickler0: Pickler[_], elemUnpickler0: Unpickler[_]):
+    Pickler[C] with Unpickler[C] = new Pickler[C] with Unpickler[C] {
 
-    val elemPickler   = elemPickler0.asInstanceOf[SPickler[AnyRef]]
+    val elemPickler   = elemPickler0.asInstanceOf[Pickler[AnyRef]]
     val elemUnpickler = elemUnpickler0.asInstanceOf[Unpickler[AnyRef]]
 
     val isPrimitive = elemTag.tpe.isEffectivelyPrimitive
@@ -150,16 +150,16 @@ trait RuntimePicklersUnpicklers {
 }
 
 
-class Tuple2RTPickler(tag: FastTypeTag[_]) extends SPickler[(Any, Any)] with Unpickler[(Any, Any)] {
+class Tuple2RTPickler(tag: FastTypeTag[_]) extends Pickler[(Any, Any)] with Unpickler[(Any, Any)] {
   def tag = FastTypeTag[(Any, Any)]
 
   def pickleField(name: String, value: Any, builder: PBuilder): Unit = {
     val (tag1, pickler1) = if (value == null) {
-      (FastTypeTag.Null.asInstanceOf[FastTypeTag[Any]], Defaults.nullPickler.asInstanceOf[SPickler[Any]])
+      (FastTypeTag.Null.asInstanceOf[FastTypeTag[Any]], Defaults.nullPickler.asInstanceOf[Pickler[Any]])
     } else {
       val clazz = value.getClass
       val tag = FastTypeTag.mkRaw(clazz, reflectRuntime.currentMirror).asInstanceOf[FastTypeTag[Any]]
-      val pickler = RuntimePicklerLookup.genPickler(clazz.getClassLoader, clazz, tag).asInstanceOf[SPickler[Any]]
+      val pickler = RuntimePicklerLookup.genPickler(clazz.getClassLoader, clazz, tag).asInstanceOf[Pickler[Any]]
       (tag, pickler)
     }
 

--- a/core/src/main/scala/pickling/runtime/GlobalRegistry.scala
+++ b/core/src/main/scala/pickling/runtime/GlobalRegistry.scala
@@ -5,8 +5,8 @@ import scala.collection.mutable
 import scala.collection.concurrent.TrieMap
 
 object GlobalRegistry {
-  val picklerMap: mutable.Map[String, FastTypeTag[_] => SPickler[_]] =
-    new TrieMap[String, FastTypeTag[_] => SPickler[_]]
+  val picklerMap: mutable.Map[String, FastTypeTag[_] => Pickler[_]] =
+    new TrieMap[String, FastTypeTag[_] => Pickler[_]]
 
   val unpicklerMap: mutable.Map[String, Unpickler[_]] =
     new TrieMap[String, Unpickler[_]]

--- a/core/src/main/scala/pickling/runtime/Runtime.scala
+++ b/core/src/main/scala/pickling/runtime/Runtime.scala
@@ -68,18 +68,18 @@ class InterpretedPicklerRuntime(classLoader: ClassLoader, preclazz: Class[_])(im
   debug("InterpretedPicklerRuntime: clazz    = " + clazz)
 
   //  TODO - this pickler should know to lock the GRL before running itself, or any mirror code.
-  def genPickler: SPickler[_] = {
+  def genPickler: Pickler[_] = {
     // build "interpreted" runtime pickler
-    new SPickler[Any] with PickleTools {
+    new Pickler[Any] with PickleTools {
       val fields: List[(irs.FieldIR, Boolean)] =
         cir.fields.filter(_.hasGetter).map(fir => (fir, fir.tpe.typeSymbol.isEffectivelyFinal))
 
       def tag: FastTypeTag[Any] = FastTypeTag.mkRaw(clazz, mirror).asInstanceOf[FastTypeTag[Any]]
 
-      def pickleInto(fieldTpe: Type, picklee: Any, builder: PBuilder, pickler: SPickler[Any]): Unit = {
+      def pickleInto(fieldTpe: Type, picklee: Any, builder: PBuilder, pickler: Pickler[Any]): Unit = {
         if (shouldBotherAboutSharing(fieldTpe))
           picklee match {
-            case null => pickler.asInstanceOf[SPickler[Null]].pickle(null, builder)
+            case null => pickler.asInstanceOf[Pickler[Null]].pickle(null, builder)
             case _ =>
               val oid = scala.pickling.internal.lookupPicklee(picklee)
               builder.hintOid(oid)
@@ -109,7 +109,7 @@ class InterpretedPicklerRuntime(classLoader: ClassLoader, preclazz: Class[_])(im
               // therefore we pass fir.tpe (as pretpe) in addition to the class and use it for the is primitive check
               //val fldRuntime = new InterpretedPicklerRuntime(classLoader, fldClass)
               val fldTag = FastTypeTag.mkRaw(fldClass, mirror)
-              val fldPickler = RuntimePicklerLookup.genPickler(classLoader, fldClass, fldTag).asInstanceOf[SPickler[Any]]
+              val fldPickler = RuntimePicklerLookup.genPickler(classLoader, fldClass, fldTag).asInstanceOf[Pickler[Any]]
 
               builder.putField(fir.name, b => {
                 if (isEffFinal) {

--- a/core/src/main/scala/pickling/runtime/RuntimePickler.scala
+++ b/core/src/main/scala/pickling/runtime/RuntimePickler.scala
@@ -75,7 +75,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
       // println(s"creating runtime pickler to pickle $fldClass field of class ${picklee.getClass.getName}")
       val fldTag = FastTypeTag.mkRaw(fldClass, mirror)
       // debug(s"!!! finding pickler for field with class ${fldClass.getName}")
-      val fldPickler = RuntimePicklerLookup.genPickler(classLoader, fldClass, fldTag).asInstanceOf[SPickler[Any]]
+      val fldPickler = RuntimePicklerLookup.genPickler(classLoader, fldClass, fldTag).asInstanceOf[Pickler[Any]]
       //debug(s"looked up field pickler: $fldPickler")
 
       builder.putField(fir.name, b => {
@@ -83,13 +83,13 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
       })
     }
 
-    def pickleLogic(fieldClass: Class[_], fieldValue: Any, builder: PBuilder, pickler: SPickler[Any], fieldTag: FastTypeTag[_]): Unit
+    def pickleLogic(fieldClass: Class[_], fieldValue: Any, builder: PBuilder, pickler: Pickler[Any], fieldTag: FastTypeTag[_]): Unit
   }
 
   final class DefaultLogic(fir: irs.FieldIR) extends Logic(fir, false) {
     // debug(s"creating DefaultLogic for ${fir.name}")
     val staticClass = mirror.runtimeClass(fir.tpe.erasure)
-    def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: SPickler[Any], fldTag: FastTypeTag[_]): Unit = {
+    def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: Pickler[Any], fldTag: FastTypeTag[_]): Unit = {
       if (fldValue == null || fldValue.getClass == staticClass) b.hintDynamicallyElidedType()
       pickleInto(fldClass, fldValue, b, fldPickler, fldTag)
     }
@@ -97,7 +97,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
 
   final class EffectivelyFinalLogic(fir: irs.FieldIR) extends Logic(fir, true) {
     // debug(s"creating EffectivelyFinalLogic for ${fir.name}")
-    def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: SPickler[Any], fldTag: FastTypeTag[_]): Unit = {
+    def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: Pickler[Any], fldTag: FastTypeTag[_]): Unit = {
       b.hintStaticallyElidedType()
       pickleInto(fldClass, fldValue, b, fldPickler, fldTag)
     }
@@ -105,7 +105,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
 
   final class AbstractLogic(fir: irs.FieldIR) extends Logic(fir, false) {
     // debug(s"creating AbstractLogic for ${fir.name}")
-    def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: SPickler[Any], fldTag: FastTypeTag[_]): Unit = {
+    def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: Pickler[Any], fldTag: FastTypeTag[_]): Unit = {
       pickleInto(fldClass, fldValue, b, fldPickler, fldTag)
     }
   }
@@ -128,7 +128,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
       // the same decision.
       // debug(s"creating tag for field of class ${fldClass.getName}")
       val fldTag = FastTypeTag.mkRaw(fldClass, mirror)
-      val fldPickler = RuntimePicklerLookup.genPickler(classLoader, fldClass, fldTag).asInstanceOf[SPickler[Any]]
+      val fldPickler = RuntimePicklerLookup.genPickler(classLoader, fldClass, fldTag).asInstanceOf[Pickler[Any]]
       // debug(s"looked up field pickler: $fldPickler")
 
       builder.putField(field.getName, b => {
@@ -136,28 +136,28 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
       })
     }
 
-    def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: SPickler[Any], fldTag: FastTypeTag[_]): Unit = {
+    def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: Pickler[Any], fldTag: FastTypeTag[_]): Unit = {
       pickleInto(fldClass, fldValue, b, fldPickler, fldTag)
     }
   }
 
   final class PrivateEffectivelyFinalJavaFieldLogic(fir: irs.FieldIR, field: Field) extends PrivateJavaFieldLogic(fir, field) {
     // debug(s"creating PrivateEffectivelyFinalJavaFieldLogic for ${fir.name}")
-    override def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: SPickler[Any], fldTag: FastTypeTag[_]): Unit = {
+    override def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: Pickler[Any], fldTag: FastTypeTag[_]): Unit = {
       b.hintStaticallyElidedType()
       pickleInto(fldClass, fldValue, b, fldPickler, fldTag)
     }
   }
 
   // difference to old runtime pickler: create tag based on fieldClass instead of fir.tpe
-  def pickleInto(fieldClass: Class[_], fieldValue: Any, builder: PBuilder, pickler: SPickler[Any], fieldTag: FastTypeTag[_]): Unit = {
+  def pickleInto(fieldClass: Class[_], fieldValue: Any, builder: PBuilder, pickler: Pickler[Any], fieldTag: FastTypeTag[_]): Unit = {
     //debug(s"fieldTag for pickleInto: ${fieldTag.key}")
     builder.hintTag(fieldTag)
 
     val fieldTpe = fieldTag.tpe
     if (shouldBotherAboutSharing(fieldTpe))
       fieldValue match {
-        case null => pickler.asInstanceOf[SPickler[Null]].pickle(null, builder)
+        case null => pickler.asInstanceOf[Pickler[Null]].pickle(null, builder)
         case _ =>
           val oid = scala.pickling.internal.lookupPicklee(fieldValue)
           builder.hintOid(oid)
@@ -172,8 +172,8 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
       pickler.pickle(fieldValue, builder)
   }
 
-  def mkPickler: SPickler[_] = {
-    new SPickler[Any] {
+  def mkPickler: Pickler[_] = {
+    new Pickler[Any] {
       val fields: List[Logic] = cir.fields.flatMap { fir =>
         if (fir.accessor.nonEmpty)
           List(

--- a/core/src/main/scala/pickling/runtime/RuntimePicklerLookup.scala
+++ b/core/src/main/scala/pickling/runtime/RuntimePicklerLookup.scala
@@ -6,13 +6,13 @@ import scala.reflect.runtime.{universe => ru}
 
 object RuntimePicklerLookup extends RuntimePicklersUnpicklers {
   // TODO - We should lock the GRL before running this method, in case we generate any picklers.
-  def genPickler(classLoader: ClassLoader, clazz: Class[_], tag: FastTypeTag[_])(implicit share: refs.Share): SPickler[_] = {
+  def genPickler(classLoader: ClassLoader, clazz: Class[_], tag: FastTypeTag[_])(implicit share: refs.Share): Pickler[_] = {
     // println(s"generating runtime pickler for $clazz") // NOTE: needs to be an explicit println, so that we don't occasionally fallback to runtime in static cases
     val className = if (clazz == null) "null" else clazz.getName
     GlobalRegistry.picklerMap.get(className) match {
       case None =>
         // debug(s"!!! could not find registered pickler for class $className, tag ${tag.key} !!!")
-        val pickler: SPickler[_] = if (clazz.isArray) {
+        val pickler: Pickler[_] = if (clazz.isArray) {
           val mirror = ru.runtimeMirror(classLoader)
           val elemClass = clazz.getComponentType()
           val elemTag = FastTypeTag.mkRaw(elemClass, mirror)

--- a/core/src/test/scala/pickling/run/binary-inputstream.scala
+++ b/core/src/test/scala/pickling/run/binary-inputstream.scala
@@ -34,7 +34,7 @@ class BinaryInputStreamReaderTest extends FunSuite {
 
   // Byte, Short, Char, Int, Long, Float, Double
 
-  def testPerson[T, U <: Person[T] : FastTypeTag](obj: U)(implicit p: SPickler[U], u: Unpickler[U]): Unit = {
+  def testPerson[T, U <: Person[T] : FastTypeTag](obj: U)(implicit p: Pickler[U], u: Unpickler[U]): Unit = {
     val pickle       = obj.pickle
     val streamPickle = BinaryPickle(new ByteArrayInputStream(pickle.value))
     val readObj      = streamPickle.unpickle[U]

--- a/core/src/test/scala/pickling/run/binary-list-int-custom-pickler-implicitly-selection.scala
+++ b/core/src/test/scala/pickling/run/binary-list-int-custom-pickler-implicitly-selection.scala
@@ -11,7 +11,7 @@ class BinaryListIntCustomTest extends FunSuite {
     val lst = (1 to 10).toList
 
     implicit def genListPickler[T](implicit format: PickleFormat): HandwrittenListIntPicklerUnpickler = new HandwrittenListIntPicklerUnpickler
-    class HandwrittenListIntPicklerUnpickler(implicit val format: PickleFormat) extends SPickler[::[Int]] with Unpickler[::[Int]] {
+    class HandwrittenListIntPicklerUnpickler(implicit val format: PickleFormat) extends Pickler[::[Int]] with Unpickler[::[Int]] {
       def pickle(picklee: ::[Int], builder: PBuilder): Unit = {
         builder.beginEntry()
         val arr = picklee.toArray

--- a/core/src/test/scala/pickling/run/binary-list-int.scala.disabled
+++ b/core/src/test/scala/pickling/run/binary-list-int.scala.disabled
@@ -9,7 +9,7 @@ import scala.collection.mutable.ListBuffer
 import org.scalatest.FunSuite
 
 class HandwrittenListIntPicklerUnpickler[Coll[_] <: List[_]](val format: PickleFormat)
-    extends SPickler[Coll[Int]] with Unpickler[Coll[Int]] {
+    extends Pickler[Coll[Int]] with Unpickler[Coll[Int]] {
 
   def pickle(picklee: Coll[Int], builder: PBuilder): Unit = {
     builder.beginEntry()
@@ -56,7 +56,7 @@ class HandwrittenListIntPicklerUnpickler[Coll[_] <: List[_]](val format: PickleF
 
 class BinaryListIntTest extends FunSuite {
   test("main") {
-    implicit def genListPickler[Coll[_] <: List[_]](implicit format: PickleFormat): SPickler[Coll[Int]] with Unpickler[Coll[Int]] =
+    implicit def genListPickler[Coll[_] <: List[_]](implicit format: PickleFormat): Pickler[Coll[Int]] with Unpickler[Coll[Int]] =
       new HandwrittenListIntPicklerUnpickler(format)
 
     val l = List[Int](7, 24, 30)

--- a/core/src/test/scala/pickling/run/bytebuffers.scala
+++ b/core/src/test/scala/pickling/run/bytebuffers.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSuite
 
 object Primitives extends Properties("bytebuffer primitive tests") {
   
-  def roundTrip[T: SPickler: Unpickler: FastTypeTag](obj: T): Boolean = {
+  def roundTrip[T: Pickler: Unpickler: FastTypeTag](obj: T): Boolean = {
     try {
       val buf = ByteBuffer.allocate(1024)
       obj.pickleTo(buf)

--- a/core/src/test/scala/pickling/run/combinator-pickleinto.scala
+++ b/core/src/test/scala/pickling/run/combinator-pickleinto.scala
@@ -33,8 +33,8 @@ class CombinatorPickleIntoTest extends FunSuite {
   test("main") {
     val data = Map(1 -> ("Jim", 30), 2 -> ("Bart", 45))
 
-    implicit def personp(implicit intp: SPickler[Int]): SPickler[Person] =
-      new SPickler[Person] {
+    implicit def personp(implicit intp: Pickler[Int]): Pickler[Person] =
+      new Pickler[Person] {
         def tag: FastTypeTag[Person] = implicitly[FastTypeTag[Person]]
         def pickle(p: Person, builder: PBuilder): Unit = {
           // let's say we only want to pickle id, since we can look up name and age based on id

--- a/core/src/test/scala/pickling/run/custom-generic-pickler.scala
+++ b/core/src/test/scala/pickling/run/custom-generic-pickler.scala
@@ -6,8 +6,8 @@ import org.scalatest.FunSuite
 case class MyClass[A](myString: String, a: A)
 
 class MyClassPickler[A](implicit val format: PickleFormat, aTypeTag: FastTypeTag[A],
-                                     aPickler: SPickler[A], aUnpickler: Unpickler[A])
-  extends SPickler[MyClass[A]] with Unpickler[MyClass[A]] {
+                                     aPickler: Pickler[A], aUnpickler: Unpickler[A])
+  extends Pickler[MyClass[A]] with Unpickler[MyClass[A]] {
 
   private val stringUnpickler = implicitly[Unpickler[String]]
 
@@ -49,7 +49,7 @@ class MyClassPickler[A](implicit val format: PickleFormat, aTypeTag: FastTypeTag
 
 class CustomGenericPicklerTest extends FunSuite {
 
-  implicit def myClassPickler[A: SPickler: Unpickler: FastTypeTag](implicit pf: PickleFormat) =
+  implicit def myClassPickler[A: Pickler: Unpickler: FastTypeTag](implicit pf: PickleFormat) =
     new MyClassPickler
 
   test("main") {

--- a/core/src/test/scala/pickling/run/externalizable-mapstatus.scala
+++ b/core/src/test/scala/pickling/run/externalizable-mapstatus.scala
@@ -149,9 +149,9 @@ class MapStatus(var location: BlockManagerId, var compressedSizes: Array[Byte])
 }
 
 class MapStatusTest extends FunSuite {
-  def register[T: ClassTag: SPickler: Unpickler](): Unit = {
+  def register[T: ClassTag: Pickler: Unpickler](): Unit = {
     val clazz = classTag[T].runtimeClass
-    val p = implicitly[SPickler[T]]
+    val p = implicitly[Pickler[T]]
     val up = implicitly[Unpickler[T]]
     GlobalRegistry.picklerMap += (clazz.getName() -> (x => p))
     GlobalRegistry.unpicklerMap += (clazz.getName() -> up)

--- a/core/src/test/scala/pickling/run/fast-byte-array.scala
+++ b/core/src/test/scala/pickling/run/fast-byte-array.scala
@@ -27,7 +27,7 @@ class FastArrayOutputTest extends FunSuite {
 
 object Primitives extends Properties("fast byte array primitive tests") {
   
-  def roundTrip[T: SPickler: Unpickler: FastTypeTag](obj: T): Boolean = {
+  def roundTrip[T: Pickler: Unpickler: FastTypeTag](obj: T): Boolean = {
     try {
       //val dummy = new FastByteArrayOutput
       val out = new FastByteArrayOutput

--- a/core/src/test/scala/pickling/run/forwarded-pickler.scala
+++ b/core/src/test/scala/pickling/run/forwarded-pickler.scala
@@ -21,7 +21,7 @@ class PicklerCanBeForwarded extends FunSuite {
   // rather than trying to generate one, this allows people
   // to call pickle/unpickle in a different place from the
   // spot where they generate the pickler.
-  private def doPickle[T](t: T)(implicit pickler1: SPickler[T]): JSONPickle =
+  private def doPickle[T](t: T)(implicit pickler1: Pickler[T]): JSONPickle =
     t.pickle
 
   private def doUnpickle[T](p: JSONPickle)(implicit unpickler1: Unpickler[T]): T =

--- a/core/src/test/scala/pickling/run/generic-spickler.scala
+++ b/core/src/test/scala/pickling/run/generic-spickler.scala
@@ -1,11 +1,11 @@
-package scala.pickling.test.generic.spickler
+package scala.pickling.test.generic.pickler
 
 import org.scalatest.FunSuite
 import scala.pickling._, scala.pickling.Defaults._, json._
 
 case class PersonY(name: String, age: Int)
 case class PersonX(name: String, age: Int, salary: Int)
-class CustomPersonXPickler(implicit val format: PickleFormat) extends SPickler[PersonX] {
+class CustomPersonXPickler(implicit val format: PickleFormat) extends Pickler[PersonX] {
   def tag: FastTypeTag[PersonX] = implicitly[FastTypeTag[PersonX]]
 
   def pickle(picklee: PersonX, builder: PBuilder) = {
@@ -19,9 +19,9 @@ class CustomPersonXPickler(implicit val format: PickleFormat) extends SPickler[P
   }
 }
 
-class GenericSpickler extends FunSuite {
+class GenericPickler extends FunSuite {
   test("stack-overflow-pickle-unpickle") {
-    def bar[T: SPickler](t: T) = t.pickle
+    def bar[T: Pickler](t: T) = t.pickle
     def unbar[T: Unpickler](s: String) = JSONPickle(s).unpickle[T]
 
     val p = PersonY("Philipp", 32)
@@ -34,11 +34,11 @@ class GenericSpickler extends FunSuite {
 
   test("issue-4") {
     implicit def genCustomPersonXPickler[T <: PersonX](implicit format: PickleFormat) = new CustomPersonXPickler
-    def fn[T <: PersonX:  SPickler](x: T) = x.pickle
+    def fn[T <: PersonX:  Pickler](x: T) = x.pickle
 
     val p = PersonX("Philipp", 32, 99999999)
     val jsn = """JSONPickle({
-      |  "tpe": "scala.pickling.test.generic.spickler.PersonX",
+      |  "tpe": "scala.pickling.test.generic.pickler.PersonX",
       |  "name": {
       |    "tpe": "java.lang.String",
       |    "value": "Philipp"

--- a/core/src/test/scala/pickling/run/sealed-trait-static-annotated.scala
+++ b/core/src/test/scala/pickling/run/sealed-trait-static-annotated.scala
@@ -1,6 +1,6 @@
 package scala.pickling.test.sealedtraitstaticannotated
 
-import scala.pickling.{PicklingException, directSubclasses, SPickler, Unpickler, Defaults }
+import scala.pickling.{PicklingException, directSubclasses, Pickler, Unpickler, Defaults }
 import scala.pickling.static._
 import scala.pickling.json._
 import Defaults.{ stringPickler, intPickler, refUnpickler, nullPickler }
@@ -86,7 +86,7 @@ class SealedTraitStaticAnnotatedTest extends FunSuite {
   }
 
   test("manually generate") {
-    implicit val pumpkinPickler = SPickler.generate[Pumpkin]
+    implicit val pumpkinPickler = Pickler.generate[Pumpkin]
     implicit val pumpkinUnpickler = Unpickler.generate[Pumpkin]
     val pumpkin = Pumpkin("Kabocha")
     val pumpkinString = pumpkin.pickle.value

--- a/core/src/test/scala/pickling/run/sealed-trait-static.scala
+++ b/core/src/test/scala/pickling/run/sealed-trait-static.scala
@@ -1,6 +1,6 @@
 package scala.pickling.test.sealedtraitstatic
 
-import scala.pickling.{ SPickler, Unpickler, PicklingException }
+import scala.pickling.{ Pickler, Unpickler, PicklingException }
 import scala.pickling.static._
 import scala.pickling.json._
 import scala.pickling.Defaults._
@@ -18,7 +18,7 @@ final case class Banana(something: Int) extends Fruit
 final case class Cucumber(something: Int) // does not extend Fruit but same shape as Banana
 
 object Fruit {
-  implicit val pickler = SPickler.generate[Fruit]
+  implicit val pickler = Pickler.generate[Fruit]
   implicit val unpickler = Unpickler.generate[Fruit]
 }
 

--- a/core/src/test/scala/pickling/run/sealed-trait.scala
+++ b/core/src/test/scala/pickling/run/sealed-trait.scala
@@ -16,7 +16,7 @@ class SealedTraitHierarchyTest extends FunSuite {
     JSONPickle(s).unpickle[T]
   }
 
-  def pickleWrapper[T](s: T)(implicit pickler1: SPickler[T], tag1: FastTypeTag[T]): String = {
+  def pickleWrapper[T](s: T)(implicit pickler1: Pickler[T], tag1: FastTypeTag[T]): String = {
     import scala.pickling.json._
     s.pickle.value
   }

--- a/core/src/test/scala/pickling/run/static-only-with-manual-pickler.scala
+++ b/core/src/test/scala/pickling/run/static-only-with-manual-pickler.scala
@@ -17,8 +17,8 @@ class StaticOnlyWithManualPicklerTest extends FunSuite {
     // StaticOnly should be happy with us, because
     // we define this pickler. If we remove this, then
     // this file should not compile.
-    implicit val picklerUnpickler: SPickler[NotClosed] with Unpickler[NotClosed] =
-      new SPickler[NotClosed] with Unpickler[NotClosed] {
+    implicit val picklerUnpickler: Pickler[NotClosed] with Unpickler[NotClosed] =
+      new Pickler[NotClosed] with Unpickler[NotClosed] {
         def pickle(picklee: NotClosed, builder: PBuilder): Unit =
           throw FakeImplementation()
         def unpickle(tag: String, reader: PReader): Any =
@@ -40,25 +40,25 @@ class StaticOnlyWithManualPicklerTest extends FunSuite {
     }
   }
 
-  // Test that you can generate SPickler without having ops._ imported on the callsite.
+  // Test that you can generate Pickler without having ops._ imported on the callsite.
   test ("manually generated pickler") {
     import scala.pickling.Defaults.intPickler
     import scala.pickling.Defaults.refPickler
     import scala.pickling.Defaults.refUnpickler
-    implicit val applePickler: SPickler[Apple] = SPickler.generate[Apple]
+    implicit val applePickler: Pickler[Apple] = Pickler.generate[Apple]
     implicit val appleUnpickler: Unpickler[Apple] = Unpickler.generate[Apple]
     val pkl: JSONPickle = pickle(Apple(1))
     val unpickled = unpickle[Apple](pkl)
     assert(Apple(1) == unpickled)
   }
 
-  // Test that you can generate SPicklerUnpickler and use it to both  pickle
+  // Test that you can generate PicklerUnpickler and use it to both  pickle
   // and unpickle
   test ("manually generated picklerunpickler") {
     import scala.pickling.Defaults.intPickler
     import scala.pickling.Defaults.refPickler
     import scala.pickling.Defaults.refUnpickler
-    implicit val applePicklerUnpickler = SPicklerUnpickler.generate[Apple]
+    implicit val applePicklerUnpickler = PicklerUnpickler.generate[Apple]
     val pkl: JSONPickle = pickle(Apple(1))
     val unpickled = unpickle[Apple](pkl)
     assert(Apple(1) == unpickled)

--- a/core/src/test/scala/pickling/run/wrapped-array.scala
+++ b/core/src/test/scala/pickling/run/wrapped-array.scala
@@ -11,8 +11,8 @@ case class Rating(x: Int)
 
 class WrappedArrayTest extends FunSuite {
   def mkAnyRefWrappedArrayPickler(implicit pf: PickleFormat):
-    SPickler[WrappedArray.ofRef[AnyRef]] with Unpickler[WrappedArray.ofRef[AnyRef]] =
-      new SPickler[WrappedArray.ofRef[AnyRef]] with Unpickler[WrappedArray.ofRef[AnyRef]] {
+    Pickler[WrappedArray.ofRef[AnyRef]] with Unpickler[WrappedArray.ofRef[AnyRef]] =
+      new Pickler[WrappedArray.ofRef[AnyRef]] with Unpickler[WrappedArray.ofRef[AnyRef]] {
 
     val format: PickleFormat = pf
 
@@ -32,7 +32,7 @@ class WrappedArrayTest extends FunSuite {
           val classLoader: ClassLoader = elemClass.getClassLoader
           val elemTag = FastTypeTag.mkRaw(elemClass, mirror) // slow: `mkRaw` is called for each element
           b.hintTag(elemTag)
-          val pickler = runtime.RuntimePicklerLookup.genPickler(classLoader, elemClass, elemTag).asInstanceOf[SPickler[AnyRef]]
+          val pickler = runtime.RuntimePicklerLookup.genPickler(classLoader, elemClass, elemTag).asInstanceOf[Pickler[AnyRef]]
           pickler.pickle(elem, b)
         }
       }


### PR DESCRIPTION
SPickler is the "default" pickler type
used almost everywhere, so give it the
bare name and leave DPickler as the exception
to the rule. Keeps newcomers from having to
think about what the "S" means.
