### PR TITLE
Handle sealed classes in check for non-cyclic types

### DIFF
--- a/core/src/test/scala/pickling/run/issue128.scala
+++ b/core/src/test/scala/pickling/run/issue128.scala
@@ -1,0 +1,22 @@
+package scala.pickling.test.issue128
+
+import scala.pickling._, scala.pickling.Defaults._
+import scala.pickling.json._
+
+import org.scalatest.FunSuite
+
+case class A(intOpt: Option[Int]) {
+  intOpt match {
+    case Some(int) =>
+    case None =>
+  }
+}
+
+class Issue128Test extends FunSuite {
+  test("Issue #128") {
+    val opt = Some(5)
+    val a = A(opt)
+    val pickle = a.pickle
+    assert(pickle.unpickle[A] === a)
+  }
+}


### PR DESCRIPTION
This is retargeted pull request for #134. Fixes #128 
## original case by @phaller

When deciding to delay the initialization of fields due to
possible cycles, sealed classes were not handled. This could
cause issues, such as #128, where the initialization of
a constructor parameter was delayed and thus the parameter
was null during the execution of the constructor.
