### PR TITLE
Improve command-line options when running benchmarks on JDK8

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,8 +3,9 @@ import Keys._
 import java.net.URL
 
 object BuildSettings {
-  val buildVersion = "0.10.0-SNAPSHOT"
+  val buildVersion      = "0.10.0-SNAPSHOT"
   val buildScalaVersion = System.getProperty("scala.version", "2.11.4")
+  val javaVersion       = System.getProperty("java.version")
   val buildSettings = Defaults.defaultSettings ++ Seq(
     version := buildVersion,
     scalaVersion := buildScalaVersion,
@@ -26,12 +27,11 @@ object MyBuild extends Build {
 
       for (len <- config) {
         import scala.sys.process._
-        var shellCommand = Seq(
-          "java", "-Dsize=" + len, "-cp", toolCP,
-          "-Xms1536M", "-Xmx4096M", "-Xss2M", "-XX:MaxPermSize=512M", "-XX:+UseParallelGC",
-          "scala.tools.nsc.MainGenericRunner", "-cp", libraryCP,
-          benchClass, "10")
-        // println(shellCommand)
+        val jdkOptions =
+          if (javaVersion.startsWith("1.8")) Seq("-XX:+UseParallelGC") else Seq("-XX:MaxPermSize=512M", "-XX:+UseParallelGC")
+        var shellCommand =
+          Seq("java", "-Dsize=" + len, "-cp", toolCP, "-Xms1536M", "-Xmx4096M", "-Xss2M") ++ jdkOptions ++
+          Seq("scala.tools.nsc.MainGenericRunner", "-cp", libraryCP, benchClass, "10")
         shellCommand.!
       }
     }


### PR DESCRIPTION
Do not pass `-XX:MaxPermSize` when running on JDK8.

This is a retargeted PR for #228
