### PR TITLE
(wip) Resurrects support for Java UUID from #123. Fixes #122

### DIFF
--- a/core/src/main/scala/pickling/pickler/AllPicklerUnpicklers.scala
+++ b/core/src/main/scala/pickling/pickler/AllPicklerUnpicklers.scala
@@ -7,6 +7,7 @@ trait AllPicklers extends PrimitivePicklers
   with DatePicklers
   with JavaBigDecimalPicklers
   with JavaBigIntegerPicklers
+  with JavaUUIDPicklers
   with PrimitiveArrayPicklers
   with RefPicklers
   with GenPicklers

--- a/core/src/test/scala/pickling/run/uuid-binary.scala
+++ b/core/src/test/scala/pickling/run/uuid-binary.scala
@@ -1,0 +1,17 @@
+package scala.pickling.uuid.binary
+
+import org.scalatest.FunSuite
+import scala.pickling._
+import scala.pickling.Defaults._
+import scala.pickling.binary._
+
+import java.util.UUID
+
+class UuidTest extends FunSuite {
+  test("main") {
+    val u = UUID.fromString("0d5d4832-af50-4a4d-837f-ef20ae862293")
+    val pickle = u.pickle
+    assert(pickle.toString === "BinaryPickle([0,0,0,14,106,97,118,97,46,117,116,105,108,46,85,85,73,68,13,93,72,50,-81,80,74,77,-125,127,-17,32,-82,-122,34,-109])")
+    assert(pickle.unpickle[UUID] === u)
+  }
+}

--- a/notes/0.10.1.markdown
+++ b/notes/0.10.1.markdown
@@ -1,0 +1,13 @@
+
+  [@mauhiz]: https://github.com/mauhiz
+
+  [123]: https://github.com/scala/pickling/pull/123
+
+### Changes with compatibility implications
+
+
+### Improvements
+
+- Java UUID support. [#123][123] by [@mauhiz][@mauhiz]
+
+### Fixes


### PR DESCRIPTION
- Adjusted to a la carte style pickler.
#123. Fixes #122
