### PR TITLE
Sealed trait in Array can pickle but cannot unpickle. Tag X not recognized, looking for one of: Y, X

### DIFF
--- a/core/src/main/scala/pickling/pickler/Iterable.scala
+++ b/core/src/main/scala/pickling/pickler/Iterable.scala
@@ -61,9 +61,7 @@ object TravPickler {
       var i = 0
       while (i < length) {
         val r = reader.readElement()
-        r.beginEntry()
-        val elem = elemUnpickler.unpickle(elemTag.key, r)
-        r.endEntry()
+        val elem = elemUnpickler.unpickleEntry(r)
         builder += elem.asInstanceOf[T]
         i = i + 1
       }

--- a/core/src/test/scala/pickling/run/sealed-trait-in-array.scala
+++ b/core/src/test/scala/pickling/run/sealed-trait-in-array.scala
@@ -1,0 +1,23 @@
+package scala.pickling.test.sealedtraitinarray
+
+import scala.pickling._
+import scala.pickling.Defaults._
+import scala.pickling.static._
+import scala.pickling.json._
+
+import org.scalatest.FunSuite
+
+sealed trait Fruit
+case class Apple(kind: String) extends Fruit
+case class Orange(kind: String) extends Fruit
+
+class SealedTraitInArrayTest extends FunSuite {
+  test("sealed trait in Array") {
+    // Type annotation is needed here otherwise you get Array[Product with Serializable with Fruit]
+    val arr: Array[Fruit] = Array(Apple("x"), Orange("x"))
+    val pkl = arr.pickle
+    // println(pkl)
+    val obj = pkl.unpickle[Array[Fruit]]
+    assert(obj === arr)
+  }
+}


### PR DESCRIPTION
This is a bug report with a failing test case. Don't merge.
## steps

```
scala-pickling> testOnly scala.pickling.test.sealedtraitinarray*
```
## problem

```
[info] SealedTraitInArrayTest:
[info] - sealed trait in Array *** FAILED ***
[info]   scala.pickling.PicklingException: Tag scala.pickling.test.sealedtraitinarray.Fruit not recognized, looking for one of: scala.pickling.test.sealedtraitinarray.Apple, scala.pickling.test.sealedtraitinarray.Orange
[info]   at scala.pickling.test.sealedtraitinarray.SealedTraitInArrayTest$$anonfun$1$ScalaPicklingTestSealedtraitinarrayFruitUnpickler$macro$24$2$.unpickle(sealed-trait-in-array.scala:20)
[info]   at scala.pickling.pickler.TravPickler$$anon$1.unpickle(Iterable.scala:65)
[info]   at scala.pickling.Unpickler$class.unpickleEntry(Pickler.scala:79)
[info]   at scala.pickling.pickler.TravPickler$$anon$1.unpickleEntry(Iterable.scala:18)
[info]   at scala.pickling.functions$.unpickle(functions.scala:11)
[info]   at scala.pickling.UnpickleOps.unpickle(Ops.scala:23)
[info]   at scala.pickling.test.sealedtraitinarray.SealedTraitInArrayTest$$anonfun$1.apply$mcV$sp(sealed-trait-in-array.scala:20)
[info]   at scala.pickling.test.sealedtraitinarray.SealedTraitInArrayTest$$anonfun$1.apply(sealed-trait-in-array.scala:15)
[info]   at scala.pickling.test.sealedtraitinarray.SealedTraitInArrayTest$$anonfun$1.apply(sealed-trait-in-array.scala:15)
[info]   at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)
```
## notes

```
JSONPickle({
  "$type": "scala.Array[scala.pickling.test.sealedtraitinarray.Fruit]",
  "elems": [
    {
    "$type": "scala.pickling.test.sealedtraitinarray.Apple",
    "kind": "x"
  },
    {
    "$type": "scala.pickling.test.sealedtraitinarray.Orange",
    "kind": "x"
  }
  ]
})
```
