### PR TITLE
stop compiling when pickler fields are empty. Fixes #60, #263

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ lazy val root: Project = (project in file(".")).
 
 /** Scala Pickling code */
 lazy val core: Project = (project in file("core")).
+  dependsOn(testUtil % "test->test").
   settings(commonSettings: _*).
   settings(
     name := "scala-pickling",
@@ -72,6 +73,9 @@ lazy val core: Project = (project in file("core")).
       baseDeps ++ additional
     }
   )
+
+lazy val testUtil: Project = (project in file("test-util")).
+  settings(commonSettings ++ noPublish: _*)
 
 lazy val sandbox: Project = (project in file("sandbox")).
   dependsOn(core).

--- a/core/src/main/scala/pickling/Macros.scala
+++ b/core/src/main/scala/pickling/Macros.scala
@@ -229,11 +229,11 @@ trait PicklerMacros extends Macro with PickleMacros with FastTypeTagMacros {
           else reflectively("picklee", fir)(fm => putField(q"$fm.get.asInstanceOf[${fir.tpe}]"))
         } else if (fir.javaSetter.isDefined) {
           List(putField(getField(fir)))
-        } else if (fir.isParam) {
+        } else if (!fir.isParam && sym.isJava) {
+          Nil
+        } else {
           reflectivelyWithoutGetter("picklee", fir)(fvalue =>
             tryPutField(q"$fvalue.asInstanceOf[scala.util.Try[${fir.tpe}]]"))
-        } else {
-          Nil
         }
       })
       if (cir.fields.nonEmpty && putFields.isEmpty) {

--- a/core/src/test/scala/pickling/NegativeCompilation.scala
+++ b/core/src/test/scala/pickling/NegativeCompilation.scala
@@ -61,9 +61,12 @@ object NegativeCompilation {
   }
 
   def toolboxClasspath = {
-    val f = new java.io.File(s"core/target/scala-${scalaBinaryVersion}/classes")
-    if (!f.exists) sys.error(s"output directory ${f.getAbsolutePath} does not exist.")
-    f.getAbsolutePath
+    val f0 = new java.io.File(s"core/target/scala-${scalaBinaryVersion}/classes")
+    val f1 = new java.io.File(s"test-util/target/scala-${scalaBinaryVersion}/test-classes")
+    val fs = Vector(f0, f1)
+    fs foreach { f => if (!f.exists) sys.error(s"output directory ${f.getAbsolutePath} does not exist.") }
+    val sep = sys.props("file.separator")
+    fs.map(_.getAbsolutePath).mkString(sep)
   }
 
   def quasiquotesJar: String = {

--- a/core/src/test/scala/pickling/neg/java-field-fail.scala
+++ b/core/src/test/scala/pickling/neg/java-field-fail.scala
@@ -1,0 +1,20 @@
+package scala.pickling.javafieldfail
+
+import scala.pickling._
+import NegativeCompilation._
+import org.scalatest.FunSuite
+
+class JavaFieldFailTest extends FunSuite {
+  test("main") {
+    expectError("Cannot generate") {
+      """import _root_.scala.pickling._
+        |import _root_.scala.pickling.Defaults._
+        |import _root_.scala.pickling.json._
+        |import _root_.scala.pickling.static._
+        |
+        |val x: java.lang.Byte = 10.toByte
+        |
+        |val p = x.pickle""".stripMargin
+    }
+  }
+}

--- a/core/src/test/scala/pickling/neg/java-field-fail.scala
+++ b/core/src/test/scala/pickling/neg/java-field-fail.scala
@@ -5,16 +5,16 @@ import NegativeCompilation._
 import org.scalatest.FunSuite
 
 class JavaFieldFailTest extends FunSuite {
-  test("main") {
+  test("x.pickle does not compile for FakeByte") {
     expectError("Cannot generate") {
       """import _root_.scala.pickling._
         |import _root_.scala.pickling.Defaults._
         |import _root_.scala.pickling.json._
         |import _root_.scala.pickling.static._
+        |import scala.pickling.javafieldfail.FakeByte
         |
-        |val x: java.lang.Byte = 10.toByte
-        |
-        |val p = x.pickle""".stripMargin
+        |val x: FakeByte = new FakeByte(10)
+        |val pkl = x.pickle""".stripMargin
     }
   }
 }

--- a/test-util/src/test/java/pickling/FakeByte.java
+++ b/test-util/src/test/java/pickling/FakeByte.java
@@ -1,0 +1,14 @@
+package scala.pickling.javafieldfail;
+
+public final class FakeByte {
+    private static final long serialVersionUID = 1L;
+    private final byte value;
+
+    public FakeByte(byte value) {
+        this.value = value;
+    }
+
+    public byte byteValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
Current implementation uses `reflectivelyWithoutGetter` to try accessing primary constructor params by name, and is allowed to fail silently. This ends up generating empty objects for Java classes like `java.lang.Byte`.
- This does not attempt reflection unless we have a known param.
- When the list of fields are non-empty, but the pickler generates zero fields, it will raise exception to fail the macro.
## over-promising issue

![venn diagram](https://docs.google.com/drawings/d/1xhvYOjTpZeXYYHp0CciKWOTcidsWcN7sXLoPVeNOi7k/pub?w=843&amp;h=495)

In the above diagram, I define _over-promising_ to be the region that's _true_ for _`x.pickle` compiles_ but `false` for _Pickler captures all necessary fields._ Here's a case that intersects with _`pkl.unpickle` unpickles..._

``` scala
scala> import scala.pickling._, Defaults._, json._, static._

scala> val r1: java.lang.Byte = 13.toByte
r1: Byte = 13

scala> val r2 = r1.pickle
r2: scala.pickling.json.pickleFormat.PickleType =
JSONPickle({
  "$type": "java.lang.Byte"
})

scala> val r3 = r2.unpickle[java.lang.Byte]
r3: Byte = 0
```
## what this changes

``` scala
scala> import scala.pickling._, Defaults._, json._, static._

scala> val r1: java.lang.Byte = 13.toByte
r1: Byte = 13

scala> val r2 = r1.pickle
<console>:20: error: Cannot generate a pickler for Byte. Recompile with -Xlog-implicits for details
       val r2 = r1.pickle
                   ^
```

Instead of going through with an empty JSON, the `Pickler[java.lang.Byte]` would no longer generate since it was not able to generate any _put fields_.

The following will continue to work.

``` scala
scala> import scala.pickling._, Defaults._, json._

scala> class Foo(x0: Int) { val x = x0 }
defined class Foo

scala> new Foo(1).pickle
res0: scala.pickling.json.pickleFormat.PickleType =
JSONPickle({
  "$type": "Foo",
  "x": 1
})
```
