### PR TITLE
Add documentation on `shareNothing` and `static`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@ Scala Pickling...
 - has **Robust Support For Object-Orientation**. While Scala Pickling is based on the elegant notion of pickler combinators from functional programming, it goes on to extend the traditional form of pickler combinators to be able to handle open class hierarchies. That means that if you pickle an instance of a subclass, and then try to unpickle as a superclass, you will still get back an instance of the original subclass.
 - **Happens At Compile-Time**. That means that it’s super-performant because serialization-related code is typically generated at compile-time and inlined where it is needed in your code. Scala Pickling is essentially fully-static, reflection is only used as a fallback when static (compile-time) generation fails.
 
+## Optimizing performance
+
+Pickling enables optimizing performance through configuration, in case the pickled objects are known to be simpler than in the general case.
+
+### Disabling cyclic object graphs
+
+By default, Pickling can serialize cyclic object graphs (for example, for serializing doubly-linked lists). However, this requires bookkeeping at run time. If pickled objects are known to be *not cyclic* (for example, simple lists or trees), then this additional bookkeeping can be disabled using the following import:
+
+```scala
+import scala.pickling.shareNothing._
+```
+
+If objects are pickled in a tight loop, this import can lead to a significant performance improvement.
+
+### Static serialization without reflection
+
+To pickle objects of types like `Any` Pickling uses run-time reflection, since not enough information is available at compile time. However, Pickling supports a static-only mode that ensures *no run-time reflection* is used. In this mode, pickling objects that would otherwise require run-time reflection causes compile-time errors.
+
+The following import enables static-only serialization:
+
+```scala
+import scala.pickling.static._  // Avoid run-time reflection
+```
+
 ## A la carte import
 
 If you want, Pickling lets you import specific parts (functions, ops, picklers, and format) so you can customize each part.


### PR DESCRIPTION
Additions to the README documenting `scala.pickling.shareNothing` and `scala.pickling.static`.

Fix #217.
