### PR TITLE
Macro Hygiene + Locking Hygiene

### DIFF
--- a/core/src/main/scala/scala/pickling/FastTags.scala
+++ b/core/src/main/scala/scala/pickling/FastTags.scala
@@ -269,9 +269,9 @@ trait FastTypeTagMacros extends Macro {
       c.abort(c.enclosingPosition, s"cannot generate FastTypeTag for type parameter $T, FastTypeTag can only be generated for concrete types")
 
     q"""
-      new scala.pickling.FastTypeTag[$T] {
-        def mirror = scala.pickling.internal.`package`.currentMirror
-        lazy val tpe = scala.reflect.runtime.universe.weakTypeOf[$T]
+      new _root_.scala.pickling.FastTypeTag[$T] {
+        def mirror = _root_.scala.pickling.internal.`package`.currentMirror
+        lazy val tpe = _root_.scala.reflect.runtime.universe.weakTypeOf[$T]
         def key = ${T.key}
       }
     """
@@ -280,15 +280,15 @@ trait FastTypeTagMacros extends Macro {
     import c.universe._
     val T = weakTypeOf[T]
     q"""
-      new scala.pickling.FastTypeTag[ClassTag[$T]] {
-        def mirror = scala.pickling.internal.`package`.currentMirror
-        lazy val tpe = scala.reflect.runtime.universe.weakTypeOf[ClassTag[$T]]
+      new _root_.scala.pickling.FastTypeTag[ClassTag[$T]] {
+        def mirror = _root_.scala.pickling.internal.`package`.currentMirror
+        lazy val tpe = _root_.scala.reflect.runtime.universe.weakTypeOf[ClassTag[$T]]
         def key = "ClassTag[" + ${T.key} + "]"
       }
     """
   }
   def apply(key: c.Tree): c.Tree = {
     import c.universe._
-    q"""scala.pickling.FastTypeTag(scala.pickling.internal.`package`.currentMirror, $key)"""
+    q"""_root_.scala.pickling.FastTypeTag(_root_.scala.pickling.internal.`package`.currentMirror, $key)"""
   }
 }

--- a/core/src/main/scala/scala/pickling/Macros.scala
+++ b/core/src/main/scala/scala/pickling/Macros.scala
@@ -53,8 +53,8 @@ trait PicklerUnpicklerMacros extends Macro
       implicit object $picklerUnpicklerName extends _root_.scala.pickling.AbstractPicklerUnpickler[$tpe] with _root_.scala.pickling.Generated
       {
         import _root_.scala.language.existentials
-        override def pickle(picklee: $tpe, builder: _root_.scala.pickling.PBuilder): Unit = $picklerTree
-        override def unpickle(tagKey: String, reader: _root_.scala.pickling.PReader): Any = $unpicklerTree
+        override def pickle(picklee: $tpe, builder: _root_.scala.pickling.PBuilder): _root_.scala.Unit = $picklerTree
+        override def unpickle(tagKey: _root_.java.lang.String, reader: _root_.scala.pickling.PReader): _root_.scala.Any = $unpicklerTree
         override def tag: _root_.scala.pickling.FastTypeTag[$tpe] = $createTagTree
       }
       $picklerUnpicklerName
@@ -340,11 +340,11 @@ trait PicklerMacros extends Macro with PickleMacros with FastTypeTagMacros {
 
     // Used to generate implicit object here
     q"""
-      locally {
+      _root_.scala.Predef.locally {
         implicit object $picklerName extends _root_.scala.pickling.Pickler[$tpe] with _root_.scala.pickling.Generated {
           import _root_.scala.pickling._
           import _root_.scala.pickling.internal._
-          def pickle(picklee: $tpe, builder: _root_.scala.pickling.PBuilder): Unit = $pickleLogicTree
+          def pickle(picklee: $tpe, builder: _root_.scala.pickling.PBuilder): _root_.scala.Unit = $pickleLogicTree
           def tag: _root_.scala.pickling.FastTypeTag[$tpe] = $createTagTree
         }
         $picklerName
@@ -361,7 +361,7 @@ trait PicklerMacros extends Macro with PickleMacros with FastTypeTagMacros {
       implicit object $picklerName extends _root_.scala.pickling.DPickler[$tpe] {
         import _root_.scala.pickling._
         import _root_.scala.pickling.internal._
-        def pickle(picklee0: $tpe, builder: _root_.scala.pickling.PBuilder): Unit = $dpicklerPickleImpl
+        def pickle(picklee0: $tpe, builder: _root_.scala.pickling.PBuilder): _root_.scala.Unit = $dpicklerPickleImpl
       }
       $picklerName
     """
@@ -423,7 +423,7 @@ trait OpenSumUnpicklerMacro extends Macro with UnpicklerMacros with FastTypeTagM
 
     q"""
       implicit object $unpicklerName extends _root_.scala.pickling.Unpickler[$tpe] with _root_.scala.pickling.Generated {
-        def unpickle(tagKey: String, reader: _root_.scala.pickling.PReader): Any = $unpickleLogic
+        def unpickle(tagKey: String, reader: _root_.scala.pickling.PReader): _root_.scala.Any = $unpickleLogic
         def tag: _root_.scala.pickling.FastTypeTag[$tpe] = $createTagTree
       }
       $unpicklerName
@@ -626,7 +626,7 @@ trait UnpicklerMacros extends Macro with UnpickleMacros with FastTypeTagMacros {
             if (tagKey == _root_.scala.pickling.FastTypeTag.Null.key) {
               null
             } else if (tagKey == _root_.scala.pickling.FastTypeTag.Ref.key) {
-              implicitly[_root_.scala.pickling.Unpickler[_root_.scala.pickling.refs.Ref]].unpickle(tagKey, reader)
+              _root_.scala.Predef.implicitly[_root_.scala.pickling.Unpickler[_root_.scala.pickling.refs.Ref]].unpickle(tagKey, reader)
             } else {
               $unpickleObject
             }
@@ -669,7 +669,7 @@ trait UnpicklerMacros extends Macro with UnpickleMacros with FastTypeTagMacros {
         import _root_.scala.pickling._
         import _root_.scala.pickling.ir._
         import _root_.scala.pickling.internal._
-        def unpickle(tagKey: String, reader: _root_.scala.pickling.PReader): Any = $unpickleLogicTree
+        def unpickle(tagKey: _root_.java.lang.String, reader: _root_.scala.pickling.PReader): _root_.scala.Any = $unpickleLogicTree
         def tag: _root_.scala.pickling.FastTypeTag[$tpe] = $createTagTree
       }
       $unpicklerName
@@ -701,7 +701,7 @@ trait PickleMacros extends Macro with TypeAnalysis {
   }
 
   def createPickler(tpe: c.Type, builder: c.Tree): c.Tree = q"""
-    val pickler = implicitly[_root_.scala.pickling.Pickler[$tpe]]
+    val pickler = _root_.scala.Predef.implicitly[_root_.scala.pickling.Pickler[$tpe]]
     $builder.hintTag(pickler.tag)
     pickler
   """
@@ -753,7 +753,7 @@ trait UnpickleMacros extends Macro with TypeAnalysis {
     readerUnpickleHelper(tpe, readerName)(true)
 
   def createUnpickler(tpe: Type): Tree =
-    q"implicitly[_root_.scala.pickling.Unpickler[$tpe]]"
+    q"_root_.scala.Predef.implicitly[_root_.scala.pickling.Unpickler[$tpe]]"
 
   def createRefDispatch(): CaseDef =
     CaseDef(Literal(Constant(FastTypeTag.Ref.key)), EmptyTree, createUnpickler(typeOf[refs.Ref]))
@@ -787,7 +787,7 @@ trait UnpickleMacros extends Macro with TypeAnalysis {
     val unpicklerName    = c.fresh(newTermName("unpickler$unpickle$"))
     q"""
       var $unpicklerName: _root_.scala.pickling.Unpickler[$tpe] = null
-      $unpicklerName = implicitly[_root_.scala.pickling.Unpickler[$tpe]]
+      $unpicklerName = _root_.scala.Predef.implicitly[_root_.scala.pickling.Unpickler[$tpe]]
       $readerName.hintTag($unpicklerName.tag)
       $staticHint
       val typeString = $readerName.beginEntry()

--- a/core/src/main/scala/scala/pickling/Macros.scala
+++ b/core/src/main/scala/scala/pickling/Macros.scala
@@ -50,7 +50,7 @@ trait PicklerUnpicklerMacros extends Macro
     val createTagTree = super[FastTypeTagMacros].impl[T]
 
     q"""
-      implicit object $picklerUnpicklerName extends _root_.scala.pickling.Pickler[$tpe] with _root_.scala.pickling.Unpickler[$tpe] with _root_.scala.pickling.Generated
+      implicit object $picklerUnpicklerName extends _root_.scala.pickling.AbstractPicklerUnpickler[$tpe] with _root_.scala.pickling.Generated
       {
         import _root_.scala.language.existentials
         import _root_.scala.pickling._

--- a/core/src/main/scala/scala/pickling/Macros.scala
+++ b/core/src/main/scala/scala/pickling/Macros.scala
@@ -53,9 +53,6 @@ trait PicklerUnpicklerMacros extends Macro
       implicit object $picklerUnpicklerName extends _root_.scala.pickling.AbstractPicklerUnpickler[$tpe] with _root_.scala.pickling.Generated
       {
         import _root_.scala.language.existentials
-        import _root_.scala.pickling._
-        import _root_.scala.pickling.ir._
-        import _root_.scala.pickling.internal._
         override def pickle(picklee: $tpe, builder: _root_.scala.pickling.PBuilder): Unit = $picklerTree
         override def unpickle(tagKey: String, reader: _root_.scala.pickling.PReader): Any = $unpicklerTree
         override def tag: _root_.scala.pickling.FastTypeTag[$tpe] = $createTagTree
@@ -346,7 +343,7 @@ trait PicklerMacros extends Macro with PickleMacros with FastTypeTagMacros {
           import _root_.scala.pickling._
           import _root_.scala.pickling.internal._
           def pickle(picklee: $tpe, builder: _root_.scala.pickling.PBuilder): Unit = $pickleLogicTree
-          def tag: FastTypeTag[$tpe] = $createTagTree
+          def tag: _root_.scala.pickling.FastTypeTag[$tpe] = $createTagTree
         }
         $picklerName
       }
@@ -423,7 +420,7 @@ trait OpenSumUnpicklerMacro extends Macro with UnpicklerMacros with FastTypeTagM
     val unpicklerName = c.fresh(syntheticUnpicklerName(tpe).toTermName)
 
     q"""
-      implicit object $unpicklerName extends scala.pickling.Unpickler[$tpe] with _root_.scala.pickling.Generated {
+      implicit object $unpicklerName extends _root_.scala.pickling.Unpickler[$tpe] with _root_.scala.pickling.Generated {
         def unpickle(tagKey: String, reader: _root_.scala.pickling.PReader): Any = $unpickleLogic
         def tag: _root_.scala.pickling.FastTypeTag[$tpe] = $createTagTree
       }
@@ -627,7 +624,7 @@ trait UnpicklerMacros extends Macro with UnpickleMacros with FastTypeTagMacros {
             if (tagKey == _root_.scala.pickling.FastTypeTag.Null.key) {
               null
             } else if (tagKey == _root_.scala.pickling.FastTypeTag.Ref.key) {
-              implicitly[Unpickler[refs.Ref]].unpickle(tagKey, reader)
+              implicitly[_root_.scala.pickling.Unpickler[_root_.scala.pickling.refs.Ref]].unpickle(tagKey, reader)
             } else {
               $unpickleObject
             }
@@ -730,9 +727,6 @@ trait PickleMacros extends Macro with TypeAnalysis {
     """
 
     q"""
-      import _root_.scala.language.existentials
-      import _root_.scala.pickling._
-      import _root_.scala.pickling.internal._
       val $pickleeName: $tpe = $picklee
       _root_.scala.pickling.internal.GRL.lock()
       try {

--- a/core/src/main/scala/scala/pickling/Macros.scala
+++ b/core/src/main/scala/scala/pickling/Macros.scala
@@ -789,18 +789,13 @@ trait UnpickleMacros extends Macro with TypeAnalysis {
     q"""
       var $unpicklerName: _root_.scala.pickling.Unpickler[$tpe] = null
       $unpicklerName = implicitly[_root_.scala.pickling.Unpickler[$tpe]]
-      _root_.scala.pickling.internal.GRL.lock()
-      try {
-        $readerName.hintTag($unpicklerName.tag)
-        $staticHint
-        val typeString = $readerName.beginEntry()
-        val result = $unpicklerName.unpickle(typeString, $readerName)
-        $readerName.endEntry()
-        $unpickleeCleanup
-        result.asInstanceOf[$tpe]
-      } finally {
-        _root_.scala.pickling.internal.GRL.unlock()
-      }
+      $readerName.hintTag($unpicklerName.tag)
+      $staticHint
+      val typeString = $readerName.beginEntry()
+      val result = $unpicklerName.unpickle(typeString, $readerName)
+      $readerName.endEntry()
+      $unpickleeCleanup
+      result.asInstanceOf[$tpe]
     """
   }
 }

--- a/core/src/main/scala/scala/pickling/PBuilderReader.scala
+++ b/core/src/main/scala/scala/pickling/PBuilderReader.scala
@@ -104,6 +104,9 @@ trait PBuilder extends Hintable {
   /** Return the resulting pickle of this builder. */
   def result(): Pickle
 }
+/** Abstract shim for Java. */
+abstract class AbtractPBuilder extends PBuilder with PickleTools
+
 
 
 /**
@@ -181,6 +184,9 @@ trait PReader extends Hintable {
   /** Denote that we are done reading a collection. */
   def endCollection(): Unit
 }
+
+/** Abstract class for Java implementors of picklers. */
+abstract class AbstractPReader extends PReader with PickleTools
 
 /**
  * Exception thrown when the pickling or unpickling process fails.

--- a/core/src/main/scala/scala/pickling/PBuilderReader.scala
+++ b/core/src/main/scala/scala/pickling/PBuilderReader.scala
@@ -104,8 +104,8 @@ trait PBuilder extends Hintable {
   /** Return the resulting pickle of this builder. */
   def result(): Pickle
 }
-/** Abstract shim for Java. */
-abstract class AbtractPBuilder extends PBuilder with PickleTools
+// Abstract shim for Java.
+abstract class AbtsractPBuilder extends PBuilder with PickleTools
 
 
 
@@ -185,7 +185,7 @@ trait PReader extends Hintable {
   def endCollection(): Unit
 }
 
-/** Abstract class for Java implementors of picklers. */
+// Abstract class for Java implementors of picklers.
 abstract class AbstractPReader extends PReader with PickleTools
 
 /**

--- a/core/src/main/scala/scala/pickling/PickleFormat.scala
+++ b/core/src/main/scala/scala/pickling/PickleFormat.scala
@@ -2,10 +2,13 @@ package scala.pickling
 
 import scala.reflect.runtime.universe.Mirror
 
-/** The location (buffer or stream) where values may be serialized.
+/** Holds the serialized representation of a value, such as an `Array[Byte]`.
   *
-  * TODO - We may want to rethink this interface a bit.  e.g. PBuilder can always return a pickle now. HOwever for
-  *        directly streamed PBuilder's we realyl don't want to do that.
+  * A `Pickle` is only returned by `PickleOps.pickle`. A directly-streamed `PBuilder` must be used together with
+  * `PickleOps.pickleTo` or `PickleOps.pickleInto` which return `Unit` instead of a pickle.
+  *
+  * When unpickling from a stream, a subclass such as `BinaryInputPickle` is used, which initializes the `value`
+  * to a dummy value. TODO - we may want to rethink this interface.
   */
 trait Pickle {
   /** The type of values stored in this pickle. */

--- a/core/src/main/scala/scala/pickling/PickleFormat.scala
+++ b/core/src/main/scala/scala/pickling/PickleFormat.scala
@@ -2,18 +2,30 @@ package scala.pickling
 
 import scala.reflect.runtime.universe.Mirror
 
-
+/** The location (buffer or stream) where values may be serialized.
+  *
+  * TODO - We may want to rethink this interface a bit.  e.g. PBuilder can always return a pickle now. HOwever for
+  *        directly streamed PBuilder's we realyl don't want to do that.
+  */
 trait Pickle {
+  /** The type of values stored in this pickle. */
   type ValueType
-
+  /* The value currently stored in this pickle. */
   val value: ValueType
 }
 
+/**
+ * A format for how to pickle the structure of an object.
+ */
 trait PickleFormat {
+  /** The type of the pickle, which stores the content of the object. */
   type PickleType <: Pickle
+  /** An output through which we can serialize objects in a streaming fashion. */
   type OutputType
-
+  /** Create a PBuilder which will serialize objects in memory, through a Pickle object. */
   def createBuilder(): PBuilder
+  /** Create a PBuilder which should serialize objects into the output directly. */
   def createBuilder(out: OutputType): PBuilder
+  /** Create a reader which can take a pickle and create a structured reader for the pickle. */
   def createReader(pickle: PickleType): PReader
 }

--- a/core/src/main/scala/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/scala/pickling/Pickler.scala
@@ -24,7 +24,7 @@ trait Pickler[T] {
   /** The fast type tag associated with this pickler. */
   def tag: FastTypeTag[T]
 }
-/** Shim for Java code. */
+// Shim for Java code.
 abstract class AbstractPickler[T] extends Pickler[T]
 object Pickler {
   def generate[T]: Pickler[T] = macro Compat.PicklerMacros_impl[T]
@@ -84,7 +84,7 @@ trait Unpickler[T] {
   /** The fast type tag associated with this unpickler. */
   def tag: FastTypeTag[T]
 }
-/** Shim for Java code. */
+// Shim for Java code.
 abstract class AbstractUnpickler[T] extends Unpickler[T]
 object Unpickler {
   def generate[T]: Unpickler[T] = macro Compat.UnpicklerMacros_impl[T]

--- a/core/src/main/scala/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/scala/pickling/Pickler.scala
@@ -24,7 +24,8 @@ trait Pickler[T] {
   /** The fast type tag associated with this pickler. */
   def tag: FastTypeTag[T]
 }
-
+/** Shim for Java code. */
+abstract class AbstractPickler[T] extends Pickler[T]
 object Pickler {
   def generate[T]: Pickler[T] = macro Compat.PicklerMacros_impl[T]
 }
@@ -83,15 +84,18 @@ trait Unpickler[T] {
   /** The fast type tag associated with this unpickler. */
   def tag: FastTypeTag[T]
 }
+/** Shim for Java code. */
+abstract class AbstractUnpickler[T] extends Unpickler[T]
 object Unpickler {
   def generate[T]: Unpickler[T] = macro Compat.UnpicklerMacros_impl[T]
 }
-
+/* Shim for java code (TODO - a good name for this.) */
+abstract class AbstractPicklerUnpickler[T] extends Pickler[T] with Unpickler[T]
 object PicklerUnpickler {
   def apply[T](p: Pickler[T], u: Unpickler[T]): Pickler[T] with Unpickler[T] = new DelegatingPicklerUnpickler(p, u)
   def generate[T]: Pickler[T] with Unpickler[T] = macro Compat.PicklerUnpicklerMacros_impl[T]
   /** This is a private implementation of PicklerUnpickler that delegates pickle and unpickle to underlying. */
-  private class DelegatingPicklerUnpickler[T](p: Pickler[T], u: Unpickler[T]) extends Pickler[T] with Unpickler[T] {
+  private class DelegatingPicklerUnpickler[T](p: Pickler[T], u: Unpickler[T]) extends AbstractPicklerUnpickler[T] {
     // From Pickler
     override def pickle(picklee: T, builder: PBuilder): Unit = p.pickle(picklee, builder)
     // From Pickler and Unpickler
@@ -101,7 +105,7 @@ object PicklerUnpickler {
   }
 }
 
-abstract class AutoRegister[T: FastTypeTag](name: String) extends Pickler[T] with Unpickler[T] {
+abstract class AutoRegister[T: FastTypeTag](name: String) extends AbstractPicklerUnpickler[T] {
   debug(s"autoregistering pickler $this under key '$name'")
   GlobalRegistry.picklerMap += (name -> (x => this))
   val tag = implicitly[FastTypeTag[T]]

--- a/core/src/main/scala/scala/pickling/Tools.scala
+++ b/core/src/main/scala/scala/pickling/Tools.scala
@@ -528,11 +528,11 @@ trait CurrentMirrorMacro extends Macro {
   def impl: c.Tree = {
     import c.universe._
     c.inferImplicitValue(typeOf[ru.Mirror], silent = true) orElse {
-      val cachedMirror = q"scala.pickling.internal.`package`.cachedMirror"
+      val cachedMirror = q"_root_.scala.pickling.internal.`package`.cachedMirror"
       q"""
         if ($cachedMirror != null) $cachedMirror
         else {
-          $cachedMirror = scala.reflect.runtime.currentMirror
+          $cachedMirror = _root_.scala.reflect.runtime.currentMirror
           $cachedMirror
         }
       """

--- a/core/src/main/scala/scala/pickling/binary/BinaryPickle.scala
+++ b/core/src/main/scala/scala/pickling/binary/BinaryPickle.scala
@@ -22,7 +22,6 @@ case class BinaryPickleArray(data: Array[Byte]) extends BinaryPickle {
 
   def createReader(format: BinaryPickleFormat): PReader =
     new BinaryPickleReader(new ByteArrayInput(data), format)
-    //new BinaryPickleReader(data, mirror, format)
 
   override def toString = s"""BinaryPickle(${value.mkString("[", ",", "]")})"""
 }

--- a/core/src/main/scala/scala/pickling/functions.scala
+++ b/core/src/main/scala/scala/pickling/functions.scala
@@ -1,7 +1,5 @@
 package scala.pickling
 
-import scala.language.experimental.macros
-
 object functions {
   def unpickle[T](thePickle: Pickle)(implicit unpickler: Unpickler[T], format: PickleFormat): T = {
     val reader = format.createReader(thePickle.asInstanceOf[format.PickleType])
@@ -10,6 +8,7 @@ object functions {
     internal.clearUnpicklees()
     result
   }
+
   def pickle[T](picklee: T)(implicit format: PickleFormat, pickler: Pickler[T]): format.PickleType = {
     val builder = format.createBuilder
     pickleInto(picklee, builder)
@@ -17,11 +16,12 @@ object functions {
     internal.clearPicklees()
     builder.result.asInstanceOf[format.PickleType]
   }
+
   def pickleInto[T](picklee: T, builder: PBuilder)(implicit pickler: Pickler[T]): Unit = {
     // TODO - BeginEntry/EndEntry needed?
     // TODO - this hinting should be in the pickler, not here.  We need to understand
     //        when we want to use this vs. something else, and avoid over-hinting everywhere.
-    if(null == picklee) {
+    if (null == picklee) {
       builder.hintTag(FastTypeTag.Null)
       Defaults.nullPickler.pickle(null, builder)
     } else {

--- a/core/src/main/scala/scala/pickling/functions.scala
+++ b/core/src/main/scala/scala/pickling/functions.scala
@@ -7,7 +7,7 @@ object functions {
     val reader = format.createReader(thePickle.asInstanceOf[format.PickleType])
     val result = unpickler.unpickleEntry(reader).asInstanceOf[T]
     // TODO - some mechanism to disable this.
-    internal.clearUnpicklees();
+    internal.clearUnpicklees()
     result
   }
   def pickle[T](picklee: T)(implicit format: PickleFormat, pickler: Pickler[T]): format.PickleType = {
@@ -21,7 +21,6 @@ object functions {
     // TODO - BeginEntry/EndEntry needed?
     // TODO - this hinting should be in the pickler, not here.  We need to understand
     //        when we want to use this vs. something else, and avoid over-hinting everywhere.
-    // TODO - Move GRL Lock only into dynamic picklers
     if(null == picklee) {
       builder.hintTag(FastTypeTag.Null)
       Defaults.nullPickler.pickle(null, builder)

--- a/core/src/main/scala/scala/pickling/pickler/Date.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Date.scala
@@ -6,7 +6,7 @@ import java.text.SimpleDateFormat
 
 trait DatePicklers extends PrimitivePicklers {
   implicit val datePickler: Pickler[Date] with Unpickler[Date] =
-  new Pickler[Date] with Unpickler[Date] {
+  new AbstractPicklerUnpickler[Date] {
     private val dateFormatTemplate = {
       val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") //use ISO_8601 format
       format.setLenient(false)

--- a/core/src/main/scala/scala/pickling/pickler/Iterable.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Iterable.scala
@@ -15,7 +15,7 @@ object TravPickler {
   def apply[T: FastTypeTag, C <% Traversable[_]]
     (implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
               cbf: CanBuildFrom[C, T, C], collTag: FastTypeTag[C]): Pickler[C] with Unpickler[C] =
-    new Pickler[C] with Unpickler[C] {
+    new AbstractPicklerUnpickler[C] {
 
     val elemTag  = implicitly[FastTypeTag[T]]
     val isPrimitive = elemTag.isEffectivelyPrimitive

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
@@ -8,7 +8,7 @@ import java.math.BigDecimal
   */
 trait JavaBigDecimalPicklers extends PrimitivePicklers {
   implicit val javaBigDecimalPickler:
-    Pickler[BigDecimal] with Unpickler[BigDecimal] = new Pickler[BigDecimal] with Unpickler[BigDecimal]{
+    Pickler[BigDecimal] with Unpickler[BigDecimal] = new AbstractPicklerUnpickler[BigDecimal] {
     def tag = FastTypeTag[BigDecimal]
     def pickle(picklee: BigDecimal, builder: PBuilder): Unit = {
       builder.beginEntry(picklee)

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
@@ -7,7 +7,7 @@ import java.math.BigInteger
 /** This contains implicits which can serialize java.math.BigInteger values. */
 trait JavaBigIntegerPicklers extends PrimitivePicklers {
   implicit val javaBigIntegerPickler:
-    Pickler[BigInteger] with Unpickler[BigInteger] = new Pickler[BigInteger] with Unpickler[BigInteger] {
+    Pickler[BigInteger] with Unpickler[BigInteger] = new AbstractPicklerUnpickler[BigInteger] {
     def tag = FastTypeTag[BigInteger]
     def pickle(picklee: BigInteger, builder: PBuilder): Unit = {
       builder.beginEntry(picklee)

--- a/core/src/main/scala/scala/pickling/pickler/JavaUUIDPickler.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaUUIDPickler.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 
 trait JavaUUIDPicklers extends PrimitivePicklers {
   implicit val javaUUIDPickler:
-    Pickler[UUID] with Unpickler[UUID] = new Pickler[UUID] with Unpickler[UUID] {
+    Pickler[UUID] with Unpickler[UUID] = new AbstractPicklerUnpickler[UUID] {
     def tag = FastTypeTag[UUID]
     def pickle(picklee: java.util.UUID, builder: PBuilder):Unit = {
       builder.beginEntry(picklee)

--- a/core/src/main/scala/scala/pickling/pickler/List.scala
+++ b/core/src/main/scala/scala/pickling/pickler/List.scala
@@ -29,7 +29,7 @@ trait CollectionPicklerUnpicklerMacro extends Macro with UnpickleMacros {
     val isFinal = eltpe.isEffectivelyFinal
     val picklerUnpicklerName = c.fresh(syntheticPicklerUnpicklerName(tpe).toTermName)
     q"""
-      implicit object $picklerUnpicklerName extends scala.pickling.Pickler[$tpe] with scala.pickling.Unpickler[$tpe] {
+      implicit object $picklerUnpicklerName extends scala.pickling.AbstractPicklerUnpickler[$tpe] {
         import scala.reflect.runtime.universe._
         import scala.pickling._
         import scala.pickling.internal._

--- a/core/src/main/scala/scala/pickling/pickler/List.scala
+++ b/core/src/main/scala/scala/pickling/pickler/List.scala
@@ -10,7 +10,7 @@ trait ListPicklerUnpicklerMacro extends CollectionPicklerUnpicklerMacro {
   lazy val ConsClass = c.mirror.staticClass("scala.collection.immutable.$colon$colon")
   def mkType(eltpe: c.Type) = appliedType(ConsClass.toTypeConstructor, List(eltpe))
   def mkArray(picklee: c.Tree) = q"$picklee.toArray"
-  def mkBuffer(eltpe: c.Type) = q"scala.collection.mutable.ListBuffer[$eltpe]()"
+  def mkBuffer(eltpe: c.Type) = q"_root_.scala.collection.mutable.ListBuffer[$eltpe]()"
   def mkResult(buffer: c.Tree) = q"$buffer.toList"
 }
 
@@ -29,30 +29,26 @@ trait CollectionPicklerUnpicklerMacro extends Macro with UnpickleMacros {
     val isFinal = eltpe.isEffectivelyFinal
     val picklerUnpicklerName = c.fresh(syntheticPicklerUnpicklerName(tpe).toTermName)
     q"""
-      implicit object $picklerUnpicklerName extends scala.pickling.AbstractPicklerUnpickler[$tpe] {
-        import scala.reflect.runtime.universe._
-        import scala.pickling._
-        import scala.pickling.internal._
-        import scala.pickling.PickleOps
+      implicit object $picklerUnpicklerName extends _root_.scala.pickling.AbstractPicklerUnpickler[$tpe] {
 
-        val elpickler: Pickler[$eltpe] = {
+        val elpickler: _root_.scala.pickling.Pickler[$eltpe] = {
           val elpickler = "bam!"
-          implicitly[Pickler[$eltpe]]
+          _root_.scala.Predef.implicitly[_root_.scala.pickling.Pickler[$eltpe]]
         }
-        val elunpickler: Unpickler[$eltpe] = {
+        val elunpickler: _root_.scala.pickling.Unpickler[$eltpe] = {
           val elunpickler = "bam!"
-          implicitly[Unpickler[$eltpe]]
+          _root_.scala.Predef.implicitly[_root_.scala.pickling.Unpickler[$eltpe]]
         }
-        val eltag: scala.pickling.FastTypeTag[$eltpe] = {
+        val eltag: _root_.scala.pickling.FastTypeTag[$eltpe] = {
           val eltag = "bam!"
-          implicitly[scala.pickling.FastTypeTag[$eltpe]]
+          _root_.scala.Predef.implicitly[_root_.scala.pickling.FastTypeTag[$eltpe]]
         }
-        val colltag: scala.pickling.FastTypeTag[$tpe] = {
+        val colltag: _root_.scala.pickling.FastTypeTag[$tpe] = {
           val colltag = "bam!"
-          implicitly[scala.pickling.FastTypeTag[$tpe]]
+          _root_.scala.Predef.implicitly[_root_.scala.pickling.FastTypeTag[$tpe]]
         }
 
-        def pickle(picklee: $tpe, builder: PBuilder): Unit = {
+        def pickle(picklee: $tpe, builder: _root_.scala.pickling.PBuilder): _root_.scala.Unit = {
           builder.hintTag(colltag)
           ${
             if (eltpe =:= IntTpe) q"builder.hintKnownSize(picklee.length * 4 + 100)".asInstanceOf[Tree]
@@ -72,11 +68,11 @@ trait CollectionPicklerUnpicklerMacro extends Macro with UnpickleMacros {
               ${
                 if (!isPrimitive && !isFinal) q"""
                   b.hintTag(eltag)
-                  PickleOps(arr(i)).pickleInto(b)
+                  _root_.scala.pickling.functions.pickleInto(arr(i), b)
                 """.asInstanceOf[Tree] else if (!isPrimitive && isFinal) q"""
                   b.hintTag(eltag)
                   b.hintStaticallyElidedType()
-                  PickleOps(arr(i)).pickleInto(b)
+                  _root_.scala.pickling.functions.pickleInto(arr(i), b)
                 """.asInstanceOf[Tree] else q"""
                   elpickler.pickle(arr(i), b)
                 """.asInstanceOf[Tree]
@@ -91,7 +87,7 @@ trait CollectionPicklerUnpicklerMacro extends Macro with UnpickleMacros {
           builder.endCollection()
           builder.endEntry()
         }
-        def unpickle(tag: => scala.pickling.FastTypeTag[_], reader: PReader): Any = {
+        def unpickle(tag: => _root_.scala.pickling.FastTypeTag[_], reader: _root_.scala.pickling.PReader): _root_.scala.Any = {
           val arrReader = reader.beginCollection()
           ${
             if (isPrimitive) q"arrReader.hintStaticallyElidedType(); arrReader.hintTag(eltag); arrReader.pinHints()".asInstanceOf[Tree]
@@ -125,7 +121,7 @@ trait CollectionPicklerUnpicklerMacro extends Macro with UnpickleMacros {
           arrReader.endCollection()
           ${mkResult(q"buffer")}
         }
-        def tag: FastTypeTag[$tpe] = colltag
+        def tag: _root_.scala.pickling.FastTypeTag[$tpe] = colltag
       }
       $picklerUnpicklerName
     """

--- a/core/src/main/scala/scala/pickling/runtime/Runtime.scala
+++ b/core/src/main/scala/scala/pickling/runtime/Runtime.scala
@@ -361,7 +361,7 @@ class ShareNothingInterpretedUnpicklerRuntime(mirror: Mirror, typeTag: String)(i
 
           inst
         }
-      } finally GRL.unlock()
+        } finally GRL.unlock()
       }
     }
   }

--- a/core/src/main/scala/scala/pickling/runtime/Runtime.scala
+++ b/core/src/main/scala/scala/pickling/runtime/Runtime.scala
@@ -133,7 +133,9 @@ class InterpretedPicklerRuntime(classLoader: ClassLoader, preclazz: Class[_])(im
 
           builder.hintTag(tag)
           builder.beginEntry(picklee)
-          putFields()
+          GRL.lock()
+          try putFields()
+          finally GRL.unlock()
           builder.endEntry()
         } else {
           builder.hintTag(FastTypeTag.Null)
@@ -179,43 +181,49 @@ class InterpretedUnpicklerRuntime(mirror: Mirror, typeTag: String)(implicit shar
     new Unpickler[Any] with PickleTools {
       def tag: FastTypeTag[Any] = fastTag.asInstanceOf[FastTypeTag[Any]]
       def unpickle(tagKey: String, reader: PReader): Any = {
-        if (cir.javaGetInstance) {
-          clazz.getDeclaredMethod("getInstance").invoke(null)
-        } else if (reader.atPrimitive) {
-          val result = reader.readPrimitive()
-          if (shouldBotherAboutSharing(tpe)) registerUnpicklee(result, preregisterUnpicklee())
-          result
-        } else if (tagKey.endsWith("$")) {
-          val c = Class.forName(tagKey)
-          c.getField("MODULE$").get(c)
-        } else {
-          val pendingFields =
-            if (tagKey.contains("anonfun$")) List[FieldIR]()
-            else cir.fields.filter(fir =>
-              fir.hasGetter || {
-                // exists as Java field
-                scala.util.Try(clazz.getDeclaredField(fir.name)).isSuccess
-              })
+        scala.pickling.internal.GRL.lock()
+        try {
+          if (cir.javaGetInstance) {
+            clazz.getDeclaredMethod("getInstance").invoke(null)
+          } else if (reader.atPrimitive) {
+            val result = reader.readPrimitive()
+            if (shouldBotherAboutSharing(tpe)) registerUnpicklee(result, preregisterUnpicklee())
+            result
+          } else if (tagKey.endsWith("$")) {
+            val c = Class.forName(tagKey)
+            c.getField("MODULE$").get(c)
+          } else {
+            val pendingFields =
+              if (tagKey.contains("anonfun$")) List[FieldIR]()
+              else cir.fields.filter(fir =>
+                fir.hasGetter || {
+                  // exists as Java field
+                  scala.util.Try(clazz.getDeclaredField(fir.name)).isSuccess
+                })
 
-          def fieldVals = pendingFields.map(fir => {
-            val freader = reader.readField(fir.name)
-            val fstaticTag = FastTypeTag(mirror, fir.tpe, fir.tpe.key)
-            freader.hintTag(fstaticTag)
+            def fieldVals = pendingFields.map(fir => {
+              val freader = reader.readField(fir.name)
+              val fstaticTag = FastTypeTag(mirror, fir.tpe, fir.tpe.key)
+              freader.hintTag(fstaticTag)
 
-            val fstaticSym = fstaticTag.tpe.typeSymbol
-            if (fstaticSym.isEffectivelyFinal) freader.hintStaticallyElidedType()
-            val fdynamicTag = try {
-              freader.beginEntry()
-            } catch {
-              case e @ PicklingException(msg, cause) =>
-                debug(s"""error in interpreted runtime unpickler while reading tag of field '${fir.name}':
+              val fstaticSym = fstaticTag.tpe.typeSymbol
+              if (fstaticSym.isEffectivelyFinal) freader.hintStaticallyElidedType()
+              val fdynamicTag = try {
+                freader.beginEntry()
+              } catch {
+                case e@PicklingException(msg, cause) =>
+                  debug( s"""error in interpreted runtime unpickler while reading tag of field '${fir.name}
+':
                          |$msg
-                         |enclosing object has type: '${tagKey}'
+
+                      |enclosing object has type: '${tagKey}
+'
                          |static type of field: '${fir.tpe.key}'
                          |""".stripMargin)
                 throw e
             }
-            val fval = {
+            val
+            fval = {
               if (freader.atPrimitive) {
                 val result = freader.readPrimitive()
                 if (shouldBotherAboutSharing(fir.tpe)) registerUnpicklee(result, preregisterUnpicklee())
@@ -253,6 +261,7 @@ class InterpretedUnpicklerRuntime(mirror: Mirror, typeTag: String)(implicit shar
 
           inst
         }
+        } finally GRL.unlock()
       }
     }
   }
@@ -279,6 +288,8 @@ class ShareNothingInterpretedUnpicklerRuntime(mirror: Mirror, typeTag: String)(i
     new Unpickler[Any] with PickleTools {
       def tag: FastTypeTag[Any] = fastTag.asInstanceOf[FastTypeTag[Any]]
       def unpickle(tagKey: String, reader: PReader): Any = {
+        GRL.lock()
+        try {
         if (reader.atPrimitive) {
           reader.readPrimitive()
         } else if (tagKey.endsWith("$")) {
@@ -350,6 +361,7 @@ class ShareNothingInterpretedUnpicklerRuntime(mirror: Mirror, typeTag: String)(i
 
           inst
         }
+      } finally GRL.unlock()
       }
     }
   }

--- a/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
@@ -201,7 +201,6 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
 
       def tag: FastTypeTag[Any] = fastTag.asInstanceOf[FastTypeTag[Any]]
 
-      // TODO - We should use the GRL here
       def pickle(picklee: Any, builder: PBuilder): Unit = {
         scala.pickling.internal.GRL.lock()
         //debug(s"pickling object of type: ${tag.key}")

--- a/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
@@ -52,6 +52,8 @@ class RuntimeTypeInfo(classLoader: ClassLoader, clazz: Class[_], share: refs.Sha
 class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTypeTag[_])(implicit share: refs.Share) extends RuntimeTypeInfo(classLoader, clazz, share) {
   import ru._
 
+  assert(scala.pickling.internal.GRL.isHeldByCurrentThread, "Failed to aquire GRL lock before instantiating a runtime pickler!")
+
   sealed abstract class Logic(fir: irs.FieldIR, isEffFinal: Boolean) {
     // debug(s"creating Logic for ${fir.name}")
     def run(builder: PBuilder, picklee: Any, im: ru.InstanceMirror): Unit = {

--- a/core/src/main/scala/scala/pickling/runtime/RuntimePicklerLookup.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimePicklerLookup.scala
@@ -5,7 +5,6 @@ import scala.reflect.runtime.{universe => ru}
 
 
 object RuntimePicklerLookup extends RuntimePicklersUnpicklers {
-  // TODO - We should lock the GRL before running this method, in case we generate any picklers.
   def genPickler(classLoader: ClassLoader, clazz: Class[_], tag: FastTypeTag[_])(implicit share: refs.Share): Pickler[_] = {
     // println(s"generating runtime pickler for $clazz") // NOTE: needs to be an explicit println, so that we don't occasionally fallback to runtime in static cases
     val className = if (clazz == null) "null" else clazz.getName

--- a/core/src/main/scala/scala/pickling/runtime/RuntimeUnpicklerLookup.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimeUnpicklerLookup.scala
@@ -25,7 +25,7 @@ object RuntimeUnpicklerLookup extends RuntimePicklersUnpicklers {
 
           mkRuntimeTravPickler[Array[AnyRef]](elemClass, elemTag, tag, null, elemUnpickler)
         } else {
-          scala.pickling.internal.GRL.lock()
+          internal.GRL.lock()
           try {
             val runtime = if (share.isInstanceOf[refs.ShareNothing]) {
               // debug(s"@@@ creating ShareNothingInterpretedUnpicklerRuntime for type $tagKey")
@@ -35,7 +35,7 @@ object RuntimeUnpicklerLookup extends RuntimePicklersUnpicklers {
               new InterpretedUnpicklerRuntime(mirror, tagKey)
             }
             runtime.genUnpickler
-          } finally scala.pickling.internal.GRL.unlock()
+          } finally internal.GRL.unlock()
         }
         GlobalRegistry.unpicklerMap += (tagKey -> unpickler)
         unpickler

--- a/core/src/main/scala/scala/pickling/runtime/RuntimeUnpicklerLookup.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimeUnpicklerLookup.scala
@@ -25,14 +25,17 @@ object RuntimeUnpicklerLookup extends RuntimePicklersUnpicklers {
 
           mkRuntimeTravPickler[Array[AnyRef]](elemClass, elemTag, tag, null, elemUnpickler)
         } else {
-          val runtime = if (share.isInstanceOf[refs.ShareNothing]) {
+          scala.pickling.internal.GRL.lock()
+          try {
+            val runtime = if (share.isInstanceOf[refs.ShareNothing]) {
               // debug(s"@@@ creating ShareNothingInterpretedUnpicklerRuntime for type $tagKey")
               new ShareNothingInterpretedUnpicklerRuntime(mirror, tagKey)
             } else {
               // debug(s"@@@ creating InterpretedUnpicklerRuntime for type $tagKey")
               new InterpretedUnpicklerRuntime(mirror, tagKey)
             }
-          runtime.genUnpickler
+            runtime.genUnpickler
+          } finally scala.pickling.internal.GRL.unlock()
         }
         GlobalRegistry.unpicklerMap += (tagKey -> unpickler)
         unpickler

--- a/core/src/test/scala/pickling/pos/TestMacroHygiene.scala
+++ b/core/src/test/scala/pickling/pos/TestMacroHygiene.scala
@@ -1,0 +1,27 @@
+package pickling.pos
+
+import scala.pickling.{Unpickler, Pickler, PicklerUnpickler}
+import scala.reflect.runtime.universe.WeakTypeTag
+
+final case class HygieneTester(x: Option[Boolean])
+/**
+ * Ensures we have pickling hygiene
+ */
+class TestMacroHygiene {
+  import _root_.scala.pickling.Defaults._
+  import _root_.scala.pickling.json._
+
+  // Workaround for scala 2.10 hygiene issues in the WeakTypeTag macros.
+  // We need to provide all of these *before* we create hygiene issues, then we can test just the pickling hygiene.
+  implicit val wtto = implicitly[WeakTypeTag[Option[Boolean]]]
+  implicit val wtts = implicitly[WeakTypeTag[Some[Boolean]]]
+  implicit val wttn = implicitly[WeakTypeTag[None.type]]
+  implicit val wttf = implicitly[WeakTypeTag[HygieneTester]]
+
+  // TODO - We should also make sure we can compile List's w/ hygiene, which I think is broken right now.
+  def hygiene(): Any = {
+    val scala, Any, String, FastTypeTag, Unit = ()
+    trait scala; trait Any; trait String; trait FastTypeTag; trait Unit;
+    HygieneTester(Option(false)).pickle.unpickle[HygieneTester]
+  }
+}

--- a/core/src/test/scala/pickling/pos/TestMacroHygiene.scala
+++ b/core/src/test/scala/pickling/pos/TestMacroHygiene.scala
@@ -3,7 +3,7 @@ package pickling.pos
 import scala.pickling.{Unpickler, Pickler, PicklerUnpickler}
 import scala.reflect.runtime.universe.WeakTypeTag
 
-final case class HygieneTester(x: Option[Boolean])
+final case class HygieneTester(x: Option[Boolean], y: Seq[String])
 /**
  * Ensures we have pickling hygiene
  */
@@ -17,11 +17,13 @@ class TestMacroHygiene {
   implicit val wtts = implicitly[WeakTypeTag[Some[Boolean]]]
   implicit val wttn = implicitly[WeakTypeTag[None.type]]
   implicit val wttf = implicitly[WeakTypeTag[HygieneTester]]
+  implicit val wttl = implicitly[WeakTypeTag[Seq[String]]]
 
+  //scala.pickling.Defaults.seqPickler
   // TODO - We should also make sure we can compile List's w/ hygiene, which I think is broken right now.
   def hygiene(): Any = {
     val scala, Any, String, FastTypeTag, Unit = ()
     trait scala; trait Any; trait String; trait FastTypeTag; trait Unit;
-    HygieneTester(Option(false)).pickle.unpickle[HygieneTester]
+    HygieneTester(Option(false), Seq("hi")).pickle.unpickle[HygieneTester]
   }
 }


### PR DESCRIPTION
This PR does two things:
1. We migrate all instances of GRL locks into dynamic sections of pickling.  ANything which _generates_ a runtime pickler is locked.   All runtime picklers which use reflection lock in their pickle/unpickle methods.
2. We fully qualify ALL types in the macro in `_root_.` which means we can remove the imports from the generated macro trees.

Should take care to review, but all tests pass and I tried an experiment with overriding sbt-server using this code, but not sure I fully refreshed the generated macro code to be clear of GRL locks.

Review by> @eed3si9n @phaller 
