### PR TITLE
Implement #359 - Force type tags in the PReader/PBuilder API.

### DIFF
--- a/core/src/main/scala/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/scala/pickling/Pickler.scala
@@ -69,7 +69,7 @@ trait Unpickler[T] {
    *        if needed.   Each Unpickler should make no assumptions about its own type.
    */
   def unpickleEntry(reader: PReader): Any = {
-    reader.hintTag(this.tag)
+    // TODO - If we are statically elided, we should HINT our type.
     val tag = reader.beginEntry()
     val result = unpickle(tag, reader)
     reader.endEntry()

--- a/core/src/main/scala/scala/pickling/Tools.scala
+++ b/core/src/main/scala/scala/pickling/Tools.scala
@@ -457,60 +457,48 @@ abstract class Macro extends RichTypes { self =>
 }
 
 case class Hints(
-  tag: FastTypeTag[_] = null,
   knownSize: Int = -1,
-  isStaticallyElidedType: Boolean = false,
-  isDynamicallyElidedType: Boolean = false,
+  elidedType: Option[FastTypeTag[_]] = None,
   oid: Int = -1,
   pinned: Boolean = false) {
-  def isElidedType = isStaticallyElidedType || isDynamicallyElidedType
+  def isElidedType = !elidedType.isEmpty
 }
 
-trait PickleTools {
+trait PickleTools extends Hintable {
   protected var hints: List[Hints] = List(Hints())
   def areHintsPinned: Boolean = hints.head.pinned
 
-  def hintTag(tag: FastTypeTag[_]): this.type = {
-    hints = hints.head.copy(tag = tag) :: hints.tail
-    this
-  }
-
-  def hintKnownSize(knownSize: Int): this.type = {
+  override def hintKnownSize(knownSize: Int): this.type = {
     hints = hints.head.copy(knownSize = knownSize) :: hints.tail
     this
   }
 
-  def hintStaticallyElidedType(): this.type = {
-    hints = hints.head.copy(isStaticallyElidedType = true) :: hints.tail
+  override def hintElidedType(tag: FastTypeTag[_]): this.type = {
+    hints = hints.head.copy(elidedType = Some(tag)) :: hints.tail
     this
   }
 
-  def hintDynamicallyElidedType(): this.type = {
-    hints = hints.head.copy(isDynamicallyElidedType = true) :: hints.tail
-    this
-  }
-
-  def hintOid(oid: Int): this.type = {
+  override def hintOid(oid: Int): this.type = {
     hints = hints.head.copy(oid = oid) :: hints.tail
     this
   }
 
-  def pinHints(): this.type = {
+  override def pinHints(): this.type = {
     hints = hints.head.copy(pinned = true) :: hints.tail
     this
   }
 
-  def unpinHints(): this.type = {
+  override def unpinHints(): this.type = {
     hints = hints.head.copy(pinned = false) :: hints.tail
     this
   }
 
-  def pushHints(): this.type = {
+  override def pushHints(): this.type = {
     hints = Hints() :: hints
     this
   }
 
-  def popHints(): this.type = {
+  override def popHints(): this.type = {
     hints = hints.tail
     this
   }

--- a/core/src/main/scala/scala/pickling/functions.scala
+++ b/core/src/main/scala/scala/pickling/functions.scala
@@ -22,13 +22,8 @@ object functions {
     // TODO - BeginEntry/EndEntry needed?
     // TODO - this hinting should be in the pickler, not here.  We need to understand
     //        when we want to use this vs. something else, and avoid over-hinting everywhere.
-    if (null == picklee) {
-      builder.hintTag(FastTypeTag.Null)
-      Defaults.nullPickler.pickle(null, builder)
-    } else {
-      builder.hintTag(pickler.tag)
-      pickler.pickle(picklee, builder)
-    }
+    if (null == picklee) Defaults.nullPickler.pickle(null, builder)
+    else pickler.pickle(picklee, builder)
   }
 
   def pickleTo[T, F <: PickleFormat](picklee: T, output: F#OutputType)(implicit pickler: Pickler[T], format: F): Unit = {

--- a/core/src/main/scala/scala/pickling/pickler/Date.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Date.scala
@@ -17,11 +17,10 @@ trait DatePicklers extends PrimitivePicklers {
 
     def tag = FastTypeTag[Date]
     def pickle(picklee: Date, builder: PBuilder): Unit = {
-      builder.beginEntry(picklee)
+      builder.beginEntry(picklee, tag)
 
       builder.putField("value", b => {
-        b.hintTag(implicitly[FastTypeTag[String]])
-        b.hintStaticallyElidedType()
+        b.hintElidedType(implicitly[FastTypeTag[String]])
         stringPickler.pickle(dateFormat.format(picklee), b)
       })
 
@@ -29,13 +28,8 @@ trait DatePicklers extends PrimitivePicklers {
     }
     def unpickle(tag: String, reader: PReader): Any = {
       val reader1 = reader.readField("value")
-      reader1.hintTag(implicitly[FastTypeTag[String]])
-      reader1.hintStaticallyElidedType()
-
-      val tag = reader1.beginEntry()
-      val result = stringPickler.unpickle(tag, reader1)
-      reader1.endEntry()
-
+      reader1.hintElidedType(implicitly[FastTypeTag[String]])
+      val result = stringPickler.unpickleEntry(reader1)
       dateFormat.parse(result.asInstanceOf[String])
     }
   }

--- a/core/src/main/scala/scala/pickling/pickler/Iterable.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Iterable.scala
@@ -28,19 +28,17 @@ object TravPickler {
 
     def pickle(coll: C, builder: PBuilder): Unit = {
       if (elemTag == FastTypeTag.Int) builder.hintKnownSize(coll.size * 4 + 100)
-      builder.beginEntry(coll)
+      builder.beginEntry(coll, tag)
       builder.beginCollection(coll.size)
 
       builder.pushHints()
       if (isPrimitive) {
-        builder.hintStaticallyElidedType()
-        builder.hintTag(elemTag)
+        builder.hintElidedType(elemTag)
         builder.pinHints()
       }
 
       (coll: Traversable[_]).asInstanceOf[Traversable[T]].foreach { (elem: T) =>
         builder putElement { b =>
-          if (!isPrimitive) b.hintTag(elemTag)
           elemPickler.pickle(elem, b)
         }
       }
@@ -55,8 +53,7 @@ object TravPickler {
 
       preader.pushHints()
       if (isPrimitive) {
-        reader.hintStaticallyElidedType()
-        reader.hintTag(elemTag)
+        reader.hintElidedType(elemTag)
         reader.pinHints()
       }
 

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
@@ -11,23 +11,17 @@ trait JavaBigDecimalPicklers extends PrimitivePicklers {
     Pickler[BigDecimal] with Unpickler[BigDecimal] = new AbstractPicklerUnpickler[BigDecimal] {
     def tag = FastTypeTag[BigDecimal]
     def pickle(picklee: BigDecimal, builder: PBuilder): Unit = {
-      builder.beginEntry(picklee)
+      builder.beginEntry(picklee, tag)
       builder.putField("value", b => {
-        b.hintTag(implicitly[FastTypeTag[String]])
-        b.hintStaticallyElidedType()
+        b.hintElidedType(implicitly[FastTypeTag[String]])
         stringPickler.pickle(picklee.toString, b)
       })
       builder.endEntry()
     }
     def unpickle(tag: String, reader: PReader): Any = {
       val reader1 = reader.readField("value")
-      reader1.hintTag(implicitly[FastTypeTag[String]])
-      reader1.hintStaticallyElidedType()
-
-      val tag = reader1.beginEntry()
-      val result = stringPickler.unpickle(tag, reader1)
-      reader1.endEntry()
-
+      reader1.hintElidedType(implicitly[FastTypeTag[String]])
+      val result = stringPickler.unpickleEntry(reader1)
       new BigDecimal(result.asInstanceOf[String])
     }
   }

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
@@ -10,11 +10,10 @@ trait JavaBigIntegerPicklers extends PrimitivePicklers {
     Pickler[BigInteger] with Unpickler[BigInteger] = new AbstractPicklerUnpickler[BigInteger] {
     def tag = FastTypeTag[BigInteger]
     def pickle(picklee: BigInteger, builder: PBuilder): Unit = {
-      builder.beginEntry(picklee)
+      builder.beginEntry(picklee, tag)
 
       builder.putField("value", b => {
-        b.hintTag(implicitly[FastTypeTag[String]])
-        b.hintStaticallyElidedType()
+        b.hintElidedType(FastTypeTag[String])
         stringPickler.pickle(picklee.toString, b)
       })
 
@@ -22,13 +21,8 @@ trait JavaBigIntegerPicklers extends PrimitivePicklers {
     }
     def unpickle(tag: String, reader: PReader): Any = {
       val reader1 = reader.readField("value")
-      reader1.hintTag(implicitly[FastTypeTag[String]])
-      reader1.hintStaticallyElidedType()
-
-      val tag = reader1.beginEntry()
-      val result = stringPickler.unpickle(tag, reader1)
-      reader1.endEntry()
-
+      reader1.hintElidedType(implicitly[FastTypeTag[String]])
+      val result = stringPickler.unpickleEntry(reader1)
       new BigInteger(result.asInstanceOf[String])
     }
   } 

--- a/core/src/main/scala/scala/pickling/pickler/JavaUUIDPickler.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaUUIDPickler.scala
@@ -8,25 +8,21 @@ trait JavaUUIDPicklers extends PrimitivePicklers {
     Pickler[UUID] with Unpickler[UUID] = new AbstractPicklerUnpickler[UUID] {
     def tag = FastTypeTag[UUID]
     def pickle(picklee: java.util.UUID, builder: PBuilder):Unit = {
-      builder.beginEntry(picklee)
-      builder.hintStaticallyElidedType()
+      builder.beginEntry(picklee, tag)
 
       builder.putField("msb", { b =>
-        b.hintTag(FastTypeTag.Long)
-        b.hintStaticallyElidedType()
+        b.hintElidedType(FastTypeTag.Long)
         longPickler.pickle(picklee.getMostSignificantBits, b)
       })
       builder.putField("lsb", { b =>
-        b.hintTag(FastTypeTag.Long)
-        b.hintStaticallyElidedType()
+        b.hintElidedType(FastTypeTag.Long)
         longPickler.pickle(picklee.getLeastSignificantBits, b)
       })
       builder.endEntry()
     }
 
     def unpickle(tag: String, reader: PReader): Any = {
-      reader.hintStaticallyElidedType()
-      reader.hintTag(FastTypeTag.Long)
+      reader.hintElidedType(FastTypeTag.Long)
       reader.pinHints()
       val r1 = reader.readField("msb")
       val tag1 = r1.beginEntry()

--- a/core/src/main/scala/scala/pickling/pickler/Primitives.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Primitives.scala
@@ -20,11 +20,12 @@ trait PrimitivePicklers {
 
 class PrimitivePickler[T: FastTypeTag](name: String) extends AutoRegister[T](name) {
   def pickle(picklee: T, builder: PBuilder): Unit = {
-    builder.beginEntry(picklee)
+    builder.beginEntry(picklee, tag)
     builder.endEntry()
   }
   def unpickle(tag: String, reader: PReader): Any = {
     try {
+      // TODO - beginEntry/endEntry?
       reader.readPrimitive()
     } catch {
       case PicklingException(msg, cause) =>

--- a/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
@@ -93,7 +93,11 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
     // debug(s"creating DefaultLogic for ${fir.name}")
     val staticClass = mirror.runtimeClass(fir.tpe.erasure)
     def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: Pickler[Any], fldTag: FastTypeTag[_]): Unit = {
-      if (fldValue == null || fldValue.getClass == staticClass) b.hintElidedType(fldTag)
+      // TODO - Dynamic elides are no longer supported, but here is where they could be.  They were never generated
+      //        for non-runtime picklers, and therefore were of little use.
+      //        The issue with dynamic elides is that the unpickler needs to support them, and it's not
+      //        somethign you could know at runtime.
+      // if (fldValue == null || fldValue.getClass == staticClass) doSomeKindofDynamicElide, perhaps
       pickleInto(fldClass, fldValue, b, fldPickler, fldTag)
     }
   }

--- a/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
@@ -93,7 +93,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
     // debug(s"creating DefaultLogic for ${fir.name}")
     val staticClass = mirror.runtimeClass(fir.tpe.erasure)
     def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: Pickler[Any], fldTag: FastTypeTag[_]): Unit = {
-      if (fldValue == null || fldValue.getClass == staticClass) b.hintDynamicallyElidedType()
+      if (fldValue == null || fldValue.getClass == staticClass) b.hintElidedType(fldTag)
       pickleInto(fldClass, fldValue, b, fldPickler, fldTag)
     }
   }
@@ -101,7 +101,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
   final class EffectivelyFinalLogic(fir: irs.FieldIR) extends Logic(fir, true) {
     // debug(s"creating EffectivelyFinalLogic for ${fir.name}")
     def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: Pickler[Any], fldTag: FastTypeTag[_]): Unit = {
-      b.hintStaticallyElidedType()
+      b.hintElidedType(fldTag)
       pickleInto(fldClass, fldValue, b, fldPickler, fldTag)
     }
   }
@@ -147,7 +147,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
   final class PrivateEffectivelyFinalJavaFieldLogic(fir: irs.FieldIR, field: Field) extends PrivateJavaFieldLogic(fir, field) {
     // debug(s"creating PrivateEffectivelyFinalJavaFieldLogic for ${fir.name}")
     override def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: Pickler[Any], fldTag: FastTypeTag[_]): Unit = {
-      b.hintStaticallyElidedType()
+      b.hintElidedType(fldTag)
       pickleInto(fldClass, fldValue, b, fldPickler, fldTag)
     }
   }
@@ -155,7 +155,6 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
   // difference to old runtime pickler: create tag based on fieldClass instead of fir.tpe
   def pickleInto(fieldClass: Class[_], fieldValue: Any, builder: PBuilder, pickler: Pickler[Any], fieldTag: FastTypeTag[_]): Unit = {
     //debug(s"fieldTag for pickleInto: ${fieldTag.key}")
-    builder.hintTag(fieldTag)
 
     val fieldTpe = fieldTag.tpe
     if (shouldBotherAboutSharing(fieldTpe))
@@ -167,7 +166,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
           if (oid == -1) {
             pickler.pickle(fieldValue, builder)
           } else {
-            builder.beginEntry(fieldValue)
+            builder.beginEntry(fieldValue, fieldTag)
             builder.endEntry()
           }
       }
@@ -207,7 +206,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
         scala.pickling.internal.GRL.lock()
         //debug(s"pickling object of type: ${tag.key}")
         try {
-          builder.beginEntry(picklee)
+          builder.beginEntry(picklee, tag)
           putFields(picklee, builder)
           builder.endEntry()
         } finally scala.pickling.internal.GRL.unlock()

--- a/core/src/test/scala/pickling/run/binary-list-int-custom-pickler-implicitly-selection.scala
+++ b/core/src/test/scala/pickling/run/binary-list-int-custom-pickler-implicitly-selection.scala
@@ -15,17 +15,16 @@ class BinaryListIntCustomTest extends FunSuite {
     implicit def genListPickler(implicit format: PickleFormat): HandwrittenListIntPicklerUnpickler = new HandwrittenListIntPicklerUnpickler
     class HandwrittenListIntPicklerUnpickler(implicit val format: PickleFormat) extends Pickler[::[Int]] with Unpickler[::[Int]] {
       def pickle(picklee: ::[Int], builder: PBuilder): Unit = {
-        builder.beginEntry()
+        builder.beginEntry(picklee, tag)
         val arr = picklee.toArray
         val length = arr.length
         builder.beginCollection(arr.length)
-        builder.hintStaticallyElidedType()
-        builder.hintTag(FastTypeTag.Int)
+        builder.hintElidedType(FastTypeTag.Int)
         builder.pinHints()
 
         var i: Int = 0
         while (i < length) {
-          builder.beginEntry(arr(i))
+          builder.beginEntry(arr(i), FastTypeTag.Int)
           builder.endEntry()
           i = i + 1
         }
@@ -36,8 +35,7 @@ class BinaryListIntCustomTest extends FunSuite {
       }
       def unpickle(tag: String, reader: PReader): Any = {
         val arrReader = reader.beginCollection()
-        arrReader.hintStaticallyElidedType()
-        arrReader.hintTag(FastTypeTag.Int)
+        arrReader.hintElidedType(FastTypeTag.Int)
         arrReader.pinHints()
 
         val buffer = ListBuffer[Int]()

--- a/core/src/test/scala/pickling/run/combinator-pickleinto.scala
+++ b/core/src/test/scala/pickling/run/combinator-pickleinto.scala
@@ -39,12 +39,10 @@ class CombinatorPickleIntoTest extends FunSuite {
         def pickle(p: Person, builder: PBuilder): Unit = {
           // let's say we only want to pickle id, since we can look up name and age based on id
           // then we can make use of a size hint, so that a fixed-size array can be used for pickling
-          builder.hintTag(implicitly[FastTypeTag[Person]])
           builder.hintKnownSize(100) // FIXME: if the value is too small, we can get java.lang.ArrayIndexOutOfBoundsException
-          builder.beginEntry(p)
+          builder.beginEntry(p, implicitly[FastTypeTag[Person]])
           builder.putField("id", b => {
-            b.hintTag(FastTypeTag.Int)
-            b.hintStaticallyElidedType()
+            b.hintElidedType(FastTypeTag.Int)
             intp.pickle(p.id, b)
           })
           builder.endEntry()
@@ -55,8 +53,7 @@ class CombinatorPickleIntoTest extends FunSuite {
       new Unpickler[Person] {
         def tag: FastTypeTag[Person] = implicitly[FastTypeTag[Person]]
         def unpickle(tag: String, reader: PReader): Any = {
-          reader.hintTag(FastTypeTag.Int)
-          reader.hintStaticallyElidedType()
+          reader.hintElidedType(FastTypeTag.Int)
           val tag = reader.beginEntry()
           val unpickled = intup.unpickle(tag, reader).asInstanceOf[Int]
           reader.endEntry()

--- a/core/src/test/scala/pickling/run/custom-generic-pickler.scala
+++ b/core/src/test/scala/pickling/run/custom-generic-pickler.scala
@@ -14,33 +14,26 @@ class MyClassPickler[A](implicit val format: PickleFormat, aTypeTag: FastTypeTag
   def tag: FastTypeTag[MyClass[A]] = implicitly[FastTypeTag[MyClass[A]]]
 
   override def pickle(picklee: MyClass[A], builder: PBuilder) = {
-    builder.beginEntry(picklee)
-
+    builder.beginEntry(picklee, tag)
     builder.putField("myString",
-      b => b.hintTag(FastTypeTag.String).beginEntry(picklee.myString).endEntry()
+      b => b.beginEntry(picklee.myString, FastTypeTag.String).endEntry()
     )
-
     builder.putField("a",
       b => {
-        b.hintTag(aTypeTag)
         aPickler.pickle(picklee.a, b)
       }
     )
-
     builder.endEntry()
   }
 
   override def unpickle(tagKey: String, reader: PReader): MyClass[A] = {
-    reader.hintTag(FastTypeTag.String)
+    // TODO - use unpickle entry, save a few lines of code.
     val tag = reader.beginEntry()
 	  val myStringUnpickled = stringUnpickler.unpickle(tag, reader).asInstanceOf[String]
 	  reader.endEntry()
-
-    reader.hintTag(aTypeTag)
     val aTag = reader.beginEntry()
     val aUnpickled = aUnpickler.unpickle(aTag, reader).asInstanceOf[A]
     reader.endEntry()
-
     MyClass(myStringUnpickled, aUnpickled)
   }
 

--- a/core/src/test/scala/pickling/run/generic-spickler.scala
+++ b/core/src/test/scala/pickling/run/generic-spickler.scala
@@ -9,10 +9,8 @@ class CustomPersonXPickler(implicit val format: PickleFormat) extends Pickler[Pe
   def tag: FastTypeTag[PersonX] = implicitly[FastTypeTag[PersonX]]
 
   def pickle(picklee: PersonX, builder: PBuilder) = {
-    builder.hintTag(implicitly[FastTypeTag[PersonX]])
-    builder.beginEntry(picklee).putField("name", b => {
-      b.hintTag(FastTypeTag.String)
-      b.beginEntry(picklee.name)
+    builder.beginEntry(picklee, tag).putField("name", b => {
+      b.beginEntry(picklee.name, FastTypeTag.String)
       b.endEntry()
     })
     builder.endEntry()

--- a/core/src/test/scala/pickling/run/non-public-separate.scala
+++ b/core/src/test/scala/pickling/run/non-public-separate.scala
@@ -7,7 +7,7 @@ class Person(private val name: String, age: Int, val hobby: Hobby) {
   // NOTE: be careful not to reference age anywhere, so that it's elided by the "constructors" phase
   override def toString = s"Person(name = $name, hobby = $hobby)"
 }
-class Hobby(var name: String, private var notes: String, private val attitude: String) {
+final class Hobby(var name: String, private var notes: String, private val attitude: String) {
   override def toString = s"Hobby(name = $name, notes = $notes, attitude = $attitude)"
 }
 

--- a/core/src/test/scala/pickling/run/non-public-separate.scala
+++ b/core/src/test/scala/pickling/run/non-public-separate.scala
@@ -7,11 +7,13 @@ class Person(private val name: String, age: Int, val hobby: Hobby) {
   // NOTE: be careful not to reference age anywhere, so that it's elided by the "constructors" phase
   override def toString = s"Person(name = $name, hobby = $hobby)"
 }
-final class Hobby(var name: String, private var notes: String, private val attitude: String) {
+class Hobby(var name: String, private var notes: String, private val attitude: String) {
   override def toString = s"Hobby(name = $name, notes = $notes, attitude = $attitude)"
 }
 
 class NonPublicSeparateTest extends FunSuite {
+  //implicit val pu = PicklerUnpickler.generate[Hobby]
+  //implicit val pu2 = PicklerUnpickler.generate[Person]
   test("main") {
     val person = new Person("Eugene", 25, new Hobby("hacking", "mostly Scala", "loving it"))
     val anyPickle = (person: Any).pickle
@@ -20,6 +22,7 @@ class NonPublicSeparateTest extends FunSuite {
       |  "$type": "scala.pickling.non.public.separate.Person",
       |  "name": "Eugene",
       |  "hobby": {
+      |    "$type": "scala.pickling.non.public.separate.Hobby",
       |    "name": "hacking",
       |    "notes": "mostly Scala",
       |    "attitude": "loving it"

--- a/core/src/test/scala/pickling/run/share-json.scala
+++ b/core/src/test/scala/pickling/run/share-json.scala
@@ -56,10 +56,20 @@ class ShareJsonTest extends FunSuite {
   }
 
   test("loop-share-nothing") {
-    intercept[StackOverflowError] {
+    /*intercept[StackOverflowError] {
       import shareNothing._
       c1.c = c3
       c2.pickle
+    }*/
+    // Note we've been running out of memory on this test in jenkins, which is also a legitimate success case
+    try {
+      import shareNothing._
+      c1.c = c3
+      c2.pickle
+      fail("Expected a stack overflow or out of memory error")
+    } catch {
+      case x: StackOverflowError => ()
+      case x: OutOfMemoryError => ()
     }
   }
 

--- a/core/src/test/scala/pickling/run/transient2.scala
+++ b/core/src/test/scala/pickling/run/transient2.scala
@@ -75,9 +75,10 @@ class Transient2SparkTest extends FunSuite {
     val sc = new SparkContext(new SparkConf(true))
     val rdd = new RDD[Int](sc, Seq(new Dependency(null)))
     // TODo - There's a bug with implicit expansion of Seq picklers, which we need to fix.
-    implicit val seqDepp = Defaults.seqPickler[Dependency[_]]
-    implicit val rddpp = PicklerUnpickler.generate[RDD[Int]]
-    implicit val fmrddp = PicklerUnpickler.generate[FlatMappedRDD[Int, Int]]
+    //implicit def depP = PicklerUnpickler.generate[Dependency[_]]
+    //implicit val seqDepp = Defaults.seqPickler[Dependency[_]]
+    //implicit val rddpp = PicklerUnpickler.generate[RDD[Int]]
+    //implicit val fmrddp = PicklerUnpickler.generate[FlatMappedRDD[Int, Int]]
     val fmrdd = new FlatMappedRDD[Int, Int](rdd, (x: Int) => (1 to x).toList)
     val p: JSONPickle =
       fmrdd.pickle


### PR DESCRIPTION
Beacuse type tags are a fundamental aspect of the design of Pickler/Unpicklers,
we now FORCE their existence for every type.
- `beginEntry` on PBuilder now takes a `FastTypeTag[_]`
- `hintStaticallyElided`, `hintDynmaicallyElided` and `hintTag` have all
  been unified into a `hintElidedType` which takes the elided tag.
- Fix both JSON + Binary format to handle the new design
- Generally simplifies hand-written picklers
- Fixed an issue with `Null` handling in JSON format.

Fixes #359 
Review by @phaller  and @eed3si9n 
