### PR TITLE
Fix OID hints

### DIFF
--- a/core/src/main/scala/scala/pickling/Tools.scala
+++ b/core/src/main/scala/scala/pickling/Tools.scala
@@ -461,7 +461,10 @@ case class Hints(
   elidedType: Option[FastTypeTag[_]] = None,
   oid: Int = -1,
   pinned: Boolean = false) {
+  /** Returns true if the type tag can be/was eldied . */
   def isElidedType = !elidedType.isEmpty
+  /** Returns true if the currently pickled object was previously pickled and can just be `shared` with the previous value. */
+  def isSharedReference: Boolean = oid != -1
 }
 
 trait PickleTools extends Hintable {

--- a/core/src/main/scala/scala/pickling/generator/sourcegen.scala
+++ b/core/src/main/scala/scala/pickling/generator/sourcegen.scala
@@ -125,13 +125,13 @@ private[pickling]  trait SourceGenerator extends Macro with FastTypeTagMacros {
       val shareHint: List[c.Tree] =
         if(shareNothing) List(q"()")
         else List(q"val $oid = _root_.scala.pickling.internal.`package`.lookupPicklee(picklee)", q"builder.hintOid($oid)")
-      val shareLogic: c.Tree =
+      /*val shareLogic: c.Tree =
         if(shareNothing) q"..$nested"
-        else q"if($oid == -1) { ..$nested }"
+        else q"if($oid == -1) { ..$nested }"*/
       q"""
          ..$shareHint
          builder.beginEntry(picklee, tag)
-         $shareLogic
+         ..$nested
          builder.endEntry()
        """
     }

--- a/core/src/main/scala/scala/pickling/json/JSONPickleFormat.scala
+++ b/core/src/main/scala/scala/pickling/json/JSONPickleFormat.scala
@@ -46,6 +46,7 @@ package json {
     private var pendingIndent = false
     private var lastIsBrace = false
     private var lastIsBracket = false
+    private var isIgnoringFields = false
     private def append(s: String) = {
       val sindent = if (pendingIndent) "  " * nindent else ""
       buf.put(sindent + s)
@@ -106,9 +107,10 @@ package json {
       val realTag =
         if(null == picklee) FastTypeTag.Null
         else tag
-      if (hints.oid != -1) {
+      if (hints.isSharedReference) {
         tags.push(FastTypeTag.Ref)
         append("{ \"$ref\": " + hints.oid + " }")
+        isIgnoringFields = true
       } else {
         tags.push(realTag)
         if (primitives.contains(realTag.key)) {
@@ -139,33 +141,39 @@ package json {
       }
       this
     }
-    def putField(name: String, pickler: PBuilder => Unit): PBuilder = {
-      // assert(!primitives.contains(tags.top.key), tags.top)
-      if (!lastIsBrace) appendLine(",") // TODO: very inefficient, but here we don't care much about performance
-      append("\"" + name + "\": ")
-      pickler(this)
+    private def ignoringSharedRef(action: => PBuilder): PBuilder =
+        if(isIgnoringFields) this
+        else action
+    def putField(name: String, pickler: PBuilder => Unit): PBuilder = ignoringSharedRef {
+        // assert(!primitives.contains(tags.top.key), tags.top)
+        if (!lastIsBrace) appendLine(",") // TODO: very inefficient, but here we don't care much about performance
+        append("\"" + name + "\": ")
+        pickler(this)
       this
     }
     def endEntry(): Unit = {
       unindent()
       if (primitives.contains(tags.pop().key)) () // do nothing
       else { appendLine(); append("}") }
+      // Always undo this state.
+      isIgnoringFields = false
     }
-    def beginCollection(length: Int): PBuilder = {
+    def beginCollection(length: Int): PBuilder = ignoringSharedRef {
       putField("elems", b => ())
       appendLine("[")
       // indent()
       this
     }
-    def putElement(pickler: PBuilder => Unit): PBuilder = {
+    def putElement(pickler: PBuilder => Unit): PBuilder = ignoringSharedRef {
       if (!lastIsBracket) appendLine(",") // TODO: very inefficient, but here we don't care much about performance
       pickler(this)
       this
     }
-    def endCollection(): Unit = {
+    def endCollection(): Unit = ignoringSharedRef {
       appendLine()
       append("]")
       // unindent()
+      this
     }
     def result(): JSONPickle = {
       assert(tags.isEmpty, tags)

--- a/core/src/main/scala/scala/pickling/json/JSONPickleFormat.scala
+++ b/core/src/main/scala/scala/pickling/json/JSONPickleFormat.scala
@@ -142,8 +142,8 @@ package json {
       this
     }
     private def ignoringSharedRef(action: => PBuilder): PBuilder =
-        if(isIgnoringFields) this
-        else action
+      if(isIgnoringFields) this
+      else action
     def putField(name: String, pickler: PBuilder => Unit): PBuilder = ignoringSharedRef {
         // assert(!primitives.contains(tags.top.key), tags.top)
         if (!lastIsBrace) appendLine(",") // TODO: very inefficient, but here we don't care much about performance

--- a/core/src/main/scala/scala/pickling/runtime/Runtime.scala
+++ b/core/src/main/scala/scala/pickling/runtime/Runtime.scala
@@ -83,12 +83,15 @@ class InterpretedPicklerRuntime(classLoader: ClassLoader, preclazz: Class[_])(im
             case _ =>
               val oid = scala.pickling.internal.lookupPicklee(picklee)
               builder.hintOid(oid)
+              pickler.pickle(picklee, builder)
+              /*
               if (oid == -1) {
                 pickler.pickle(picklee, builder)
               } else {
                 builder.beginEntry(picklee, tag)
                 builder.endEntry()
               }
+              */
           }
         else
           pickler.pickle(picklee, builder)

--- a/core/src/main/scala/scala/pickling/runtime/Runtime.scala
+++ b/core/src/main/scala/scala/pickling/runtime/Runtime.scala
@@ -84,14 +84,6 @@ class InterpretedPicklerRuntime(classLoader: ClassLoader, preclazz: Class[_])(im
               val oid = scala.pickling.internal.lookupPicklee(picklee)
               builder.hintOid(oid)
               pickler.pickle(picklee, builder)
-              /*
-              if (oid == -1) {
-                pickler.pickle(picklee, builder)
-              } else {
-                builder.beginEntry(picklee, tag)
-                builder.endEntry()
-              }
-              */
           }
         else
           pickler.pickle(picklee, builder)

--- a/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
@@ -169,12 +169,6 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
           builder.hintOid(oid)
           // Note: Now we always pickle fully, and the format decides whether to share.
           pickler.pickle(fieldValue, builder)
-          /*if (oid == -1) {
-            pickler.pickle(fieldValue, builder)
-          } else {
-            builder.beginEntry(fieldValue, fieldTag)
-            builder.endEntry()
-          }*/
       }
     else
       pickler.pickle(fieldValue, builder)

--- a/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
@@ -167,12 +167,14 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
         case _ =>
           val oid = scala.pickling.internal.lookupPicklee(fieldValue)
           builder.hintOid(oid)
-          if (oid == -1) {
+          // Note: Now we always pickle fully, and the format decides whether to share.
+          pickler.pickle(fieldValue, builder)
+          /*if (oid == -1) {
             pickler.pickle(fieldValue, builder)
           } else {
             builder.beginEntry(fieldValue, fieldTag)
             builder.endEntry()
-          }
+          }*/
       }
     else
       pickler.pickle(fieldValue, builder)


### PR DESCRIPTION
Note - This depends on #361.  

This alters the `oid` hint framework of pickling so that `oid` is a completely optional thing for builders/readers to either implement or not.

Review by @phaller  cc> @eed3si9n 
