### PR TITLE
Type constructor runtime pickler generation

### DIFF
--- a/core/src/main/scala/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/scala/pickling/Pickler.scala
@@ -106,8 +106,8 @@ abstract class AutoRegister[T: FastTypeTag](name: String) extends AbstractPickle
   // Register this pickler with the global handler.
   locally {
     val p = internal.currentRuntime.picklers
-    debug(s"autoregistering pickler $this under key '$name'")
-    p.registerPickler(name, this)
+    debug(s"autoregistering pickler $this under key '${tag.key}'")
+    p.registerPickler(tag.key, this)
     debug(s"autoregistering unpickler $this under key '${tag.key}'")
     p.registerUnpickler(tag.key, this)
   }

--- a/core/src/main/scala/scala/pickling/internal/AppliedType.scala
+++ b/core/src/main/scala/scala/pickling/internal/AppliedType.scala
@@ -1,14 +1,17 @@
 package scala.pickling.internal
 
+import scala.pickling.PicklingException
+
 object AppliedType {
   // the delimiters in an applied type
   private val delims = List(',', '[', ']')
 
-  /* Parse an applied type.
+  /* Parse an applied type. (Helper method)
    *
    * @param  s the string that is parsed
    * @return   a pair with the parsed applied type and the remaining string.
    */
+  @deprecated("Will no longer be public", "0.11.0")
   def parse(s: String): (AppliedType, String) = {
     // shape of `s`: fqn[at_1, ..., at_n]
     val (typename, rem) = s.span(!delims.contains(_))
@@ -28,6 +31,17 @@ object AppliedType {
 
       (AppliedType(typename, typeArgs), if (remaining.startsWith("]")) remaining.substring(1) else remaining)
     }
+  }
+
+  /* Parse an applied type.
+ *
+ * @param  s the string that is parsed
+ * @return   The applied type, or None if we found leftovers in the string.
+ */
+  def parseFull(s: String): Option[AppliedType] = {
+    val (result, remaining) = parse(s)
+    if(remaining.isEmpty) Some(result)
+    else None
   }
 
 }

--- a/core/src/main/scala/scala/pickling/internal/AutoDefaultRuntimePicklers.scala
+++ b/core/src/main/scala/scala/pickling/internal/AutoDefaultRuntimePicklers.scala
@@ -41,41 +41,13 @@ trait RuntimePicklerRegistryHelper extends PicklerRegistry {
     registerUnpickler("scala.Tuple2$mcZD$sp", (new Tuple2RTPickler(null)))
     registerUnpickler("scala.Tuple2$mcZC$sp", (new Tuple2RTPickler(null)))
     registerUnpickler("scala.Tuple2$mcZZ$sp", (new Tuple2RTPickler(null)))
+
+    // TODO - Does this work the way we want?
+    registerPicklerGenerator("scala.Tuple2", tuplePicklerGenerator)
   }
-  /** Helper to lookup the very odd, and poorly behaved Tuple2 classes. */
-  def lookupTupleSpecialPicklers(classKey: String, tag: FastTypeTag[_]): Option[Pickler[_]] = {
-    classKey match {
-      case "scala.Tuple2"         => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcII$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcIJ$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcID$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcIC$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcIZ$sp" => Some( new Tuple2RTPickler (tag) )
-  
-      case "scala.Tuple2$mcJI$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcJJ$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcJD$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcJC$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcJZ$sp" => Some( new Tuple2RTPickler (tag) )
-  
-      case "scala.Tuple2$mcDI$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcDJ$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcDD$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcDC$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcDZ$sp" => Some( new Tuple2RTPickler (tag) )
-  
-      case "scala.Tuple2$mcCI$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcCJ$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcCD$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcCC$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcCZ$sp" => Some( new Tuple2RTPickler (tag) )
-  
-      case "scala.Tuple2$mcZI$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcZJ$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcZD$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcZC$sp" => Some( new Tuple2RTPickler (tag) )
-      case "scala.Tuple2$mcZZ$sp" => Some( new Tuple2RTPickler (tag) )
-      case _ => None
-    }
-  } 
+
+  def tuplePicklerGenerator: AppliedType => Pickler[_] = { tpe =>
+    val tag = FastTypeTag.apply(internal.currentMirror, tpe.toString)
+    new Tuple2RTPickler(tag)
+  }
 }

--- a/core/src/main/scala/scala/pickling/internal/AutoDefaultRuntimePicklers.scala
+++ b/core/src/main/scala/scala/pickling/internal/AutoDefaultRuntimePicklers.scala
@@ -46,7 +46,7 @@ trait RuntimePicklerRegistryHelper extends PicklerRegistry {
     registerPicklerGenerator("scala.Tuple2", tuplePicklerGenerator)
   }
 
-  def tuplePicklerGenerator: AppliedType => Pickler[_] = { tpe =>
+  def tuplePicklerGenerator: AppliedType => Pickler[(Any,Any)] = { tpe =>
     val tag = FastTypeTag.apply(internal.currentMirror, tpe.toString)
     new Tuple2RTPickler(tag)
   }

--- a/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
@@ -75,14 +75,17 @@ final class DefaultPicklerRegistry(generator: RuntimePicklerGenerator) extends P
 
   /** Looks for a pickler with the given FastTypeTag string. */
   override def lookupPickler(key: String): Option[Pickler[_]] = {
+    System.err.println(s"Looking up pickler for: $key")
     picklerMap.get(key) match {
       case x: Some[Pickler[_]] => x
       case None =>
         // TODO - fix AppliedType for a `parseAll` string or some such.
         val (a, remaining) = AppliedType.parse(key)
-        if(remaining.isEmpty && !a.typeargs.isEmpty) {
+        if(remaining.isEmpty) {
+          System.err.println(s"Looking up unpickler generator for: ${a.typename}")
           picklerGenMap.get(a.typename) match {
             case Some(gen) =>
+              System.err.println(s"Generating pickler for: $key")
               // Genereate the pickler, register it with ourselves for future lookup, and return it.
               val up = gen(a)
               registerPickler(key, up)

--- a/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
@@ -60,7 +60,7 @@ final class DefaultPicklerRegistry(generator: RuntimePicklerGenerator) extends P
       case None =>
         // Now we use the typeConstructor registry
         val (a, remaining) = AppliedType.parse(key)
-        if(remaining.isEmpty && !a.typeargs.isEmpty) {
+        if(remaining.isEmpty) {
           unpicklerGenMap.get(a.typename) match {
             case Some(gen) =>
               // Genereate the pickler, register it with ourselves for future lookup, and return it.

--- a/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
@@ -10,34 +10,37 @@ import scala.pickling.spi.{PicklerRegistry, RuntimePicklerGenerator}
 
 /** Default pickle registry just uses TrieMaps and delgates behavior to a runtime pickler generator. */
 final class DefaultPicklerRegistry(generator: RuntimePicklerGenerator) extends PicklerRegistry with RuntimePicklerRegistryHelper {
+  type PicklerGenerator = AppliedType => Pickler[_]
+  type UnpicklerGenerator = AppliedType => Unpickler[_]
   // TODO - We need to move the special encoding for runtime classes into here, rather than in magical traits.
 
   private val picklerMap: mutable.Map[String, Pickler[_]] = new TrieMap[String, Pickler[_]]
+  private val picklerGenMap: mutable.Map[String, PicklerGenerator] = new TrieMap[String, PicklerGenerator]
   private val unpicklerMap: mutable.Map[String, Unpickler[_]] = new TrieMap[String, Unpickler[_]]
+  private val unpicklerGenMap: mutable.Map[String, UnpicklerGenerator] = new TrieMap[String, UnpicklerGenerator]
 
   // During constrcution, we can now register the default picklers against our cache of picklers.
   autoRegisterDefaults()
 
   /** Looks up the registered unpickler using the provided tagKey. */
   override def genUnpickler(mirror: Mirror, tagKey: String)(implicit share: refs.Share): Unpickler[_] = {
-    unpicklerMap.get(tagKey) match {
+    lookupUnpickler(tagKey) match {
       case Some(p) => p
       case None =>
+        // TODO - This should probably just be taking the `tagKey` and no mirror or share, the mirror/share
+        //        should be configured by the default runtime.
         val p = generator.genUnpickler(mirror, tagKey)
         registerUnpickler(tagKey, p)
         p
     }
   }
   def genPickler(classLoader: ClassLoader, clazz: Class[_], tag: FastTypeTag[_])(implicit share: refs.Share): Pickler[_] = {
-    // TODO - The whole mechanism we use here seems pretty bad.  We should probably always store using the TAG, and keep the TUple2 magikz out of our storage.
-    //        For now this code is just mimicking what was tehre before, we can clean up in the future.
-    val className = if (clazz == null) "null" else clazz.getName
-    // First check the special tuple picklers
-    lookupTupleSpecialPicklers(className, tag).orElse(picklerMap.get(className)) match {
+    lookupPickler(tag.key) match {
       case Some(p) => p
       case None =>
+        // TODO - genPickler should probably just be using the tag and `currentMirror` of internal.
         val p = generator.genPickler(classLoader, clazz, tag)
-        registerPickler(className, p)
+        registerPickler(tag.key, p)
         p
     }
   }
@@ -51,5 +54,62 @@ final class DefaultPicklerRegistry(generator: RuntimePicklerGenerator) extends P
     unpicklerMap.put(key, p)
 
   /** Checks the existince of an unpickler. */
-  override def lookupUnpickler(key: String): Option[Unpickler[_]] = unpicklerMap.get(key)
+  override def lookupUnpickler(key: String): Option[Unpickler[_]] = {
+    unpicklerMap.get(key) match {
+      case x: Some[Unpickler[_]] => x
+      case None =>
+        // Now we use the typeConstructor registry
+        val (a, remaining) = AppliedType.parse(key)
+        if(remaining.isEmpty && !a.typeargs.isEmpty) {
+          unpicklerGenMap.get(a.typename) match {
+            case Some(gen) =>
+              // Genereate the pickler, register it with ourselves for future lookup, and return it.
+              val up = gen(a)
+              registerUnpickler(key, up)
+              Some(up)
+            case None => None
+          }
+        } else None // This key is not an applied type.
+    }
+  }
+
+  /** Looks for a pickler with the given FastTypeTag string. */
+  override def lookupPickler(key: String): Option[Pickler[_]] = {
+    picklerMap.get(key) match {
+      case x: Some[Pickler[_]] => x
+      case None =>
+        // TODO - fix AppliedType for a `parseAll` string or some such.
+        val (a, remaining) = AppliedType.parse(key)
+        if(remaining.isEmpty && !a.typeargs.isEmpty) {
+          picklerGenMap.get(a.typename) match {
+            case Some(gen) =>
+              // Genereate the pickler, register it with ourselves for future lookup, and return it.
+              val up = gen(a)
+              registerPickler(key, up)
+              Some(up)
+            case None => None
+          }
+        } else None // This key is not an applied type.
+    }
+
+  }
+
+  /** Registers a function which can generate picklers for a given type constructor.
+    *
+    * @param typeConstructorKey  The type constructor.  e.g. "scala.List" for something that can make scala.List[A] picklers.
+    * @param generator  A function which takes an applied type string (your type + arguments) and returns a pickler for
+    *                   this type.
+    */
+  override def registerUnpicklerGenerator(typeConstructorKey: String, generator: (AppliedType) => Unpickler[_]): Unit =
+    unpicklerGenMap.put(typeConstructorKey, generator)
+
+
+  /** Registers a function which can generate picklers for a given type constructor.
+    *
+    * @param typeConstructorKey  The type constructor.  e.g. "scala.List" for something that can make scala.List[A] picklers.
+    * @param generator  A function which takes an applied type string (your type + arguments) and returns a pickler for
+    *                   this type.
+    */
+  override def registerPicklerGenerator(typeConstructorKey: String, generator: (AppliedType) => Pickler[_]): Unit =
+    picklerGenMap.put(typeConstructorKey, generator)
 }

--- a/core/src/main/scala/scala/pickling/internal/DefaultRuntimePicklerGenerator.scala
+++ b/core/src/main/scala/scala/pickling/internal/DefaultRuntimePicklerGenerator.scala
@@ -50,6 +50,7 @@ class DefaultRuntimePicklerGenerator(reflectionLock: ReentrantLock) extends spi.
         // debug(s"runtime unpickling of an array: $tagKey")
         val elemTypeString = tagKey.substring(12, tagKey.length - 1)
         // debug(s"creating tag for element type: $elemTypeString")
+        // TODO - If the elem tag is not something useful, we should treat it as `Any`...
         val elemTag = FastTypeTag(currentRuntime.currentMirror, elemTypeString)
         val elemClass = Classes.classFromString(elemTypeString)
         val elemUnpickler = internal.currentRuntime.picklers.genUnpickler(mirror, elemTypeString)

--- a/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
+++ b/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
@@ -21,12 +21,14 @@ final class NoReflectionRuntime() extends PicklingRuntime {
       throw new UnsupportedOperationException(s"Runtime pickler generation is disabled.  Cannot create unpickler for $tagKey")
     override def genPickler(classLoader: ClassLoader, clazz: Class[_], tag: FastTypeTag[_])(implicit share: Share): Pickler[_] =
       throw new UnsupportedOperationException(s"Runtime pickler generation is disabled.  Cannot create pickler for $tag")
-    override def registerPickler(key: String, p: Pickler[_]): Unit = ()
     override def lookupUnpickler(key: String): Option[Unpickler[_]] = None
-    override def registerUnpickler(key: String, p: Unpickler[_]): Unit = ()
     override def lookupPickler(key: String): Option[Pickler[_]] = None
-    override def registerUnpicklerGenerator(typeConstructorKey: String, generator: (AppliedType) => Unpickler[_]): Unit = ()
-    override def registerPicklerGenerator(typeConstructorKey: String, generator: (AppliedType) => Pickler[_]): Unit = ()
+    override def registerPickler[T](key: String, p: Pickler[T]): Unit = ()
+    override def registerUnpicklerGenerator[T](typeConstructorKey: String, generator: (AppliedType) => Unpickler[T]): Unit = ()
+    override def registerPicklerUnpicklerGenerator[T](typeConstructorKey: String, generator: (AppliedType) => Pickler[T] with Unpickler[T]): Unit = ()
+    override def registerPicklerGenerator[T](typeConstructorKey: String, generator: (AppliedType) => Pickler[T]): Unit = ()
+    override def registerUnpickler[T](key: String, p: Unpickler[T]): Unit = ()
+    override def registerPicklerUnpickler[T](key: String, p: Pickler[T] with Unpickler[T]): Unit = ()
   }
   override val refRegistry: RefRegistry = new DefaultRefRegistry()
   override val GRL: ReentrantLock = new ReentrantLock()

--- a/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
+++ b/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
@@ -15,6 +15,7 @@ final class NoReflectionRuntime() extends PicklingRuntime {
   /** The current reflection mirror to use when doing runtime unpickling/pickling. */
   override def currentMirror: runtime.universe.Mirror = runtime.currentMirror
 
+  // TODO - we should allow registered picklers, just no reflective pickler generation...
   object picklers extends PicklerRegistry {
     override def genUnpickler(mirror: runtime.universe.Mirror, tagKey: String)(implicit share: refs.Share): _root_.scala.pickling.Unpickler[_] =
       throw new UnsupportedOperationException(s"Runtime pickler generation is disabled.  Cannot create unpickler for $tagKey")
@@ -23,6 +24,9 @@ final class NoReflectionRuntime() extends PicklingRuntime {
     override def registerPickler(key: String, p: Pickler[_]): Unit = ()
     override def lookupUnpickler(key: String): Option[Unpickler[_]] = None
     override def registerUnpickler(key: String, p: Unpickler[_]): Unit = ()
+    override def lookupPickler(key: String): Option[Pickler[_]] = None
+    override def registerUnpicklerGenerator(typeConstructorKey: String, generator: (AppliedType) => Unpickler[_]): Unit = ()
+    override def registerPicklerGenerator(typeConstructorKey: String, generator: (AppliedType) => Pickler[_]): Unit = ()
   }
   override val refRegistry: RefRegistry = new DefaultRefRegistry()
   override val GRL: ReentrantLock = new ReentrantLock()

--- a/core/src/main/scala/scala/pickling/internal/package.scala
+++ b/core/src/main/scala/scala/pickling/internal/package.scala
@@ -58,8 +58,8 @@ package object internal {
     if (typeFromStringCache.contains(stpe)) typeFromStringCache(stpe)
     else {
       val result =
-        AppliedType.parse(stpe) match {
-          case (AppliedType(typename, appliedTypeArgs), _) =>
+        AppliedType.parseFull(stpe) match {
+          case Some(AppliedType(typename, appliedTypeArgs)) =>
             def errorMsg = s"""error: cannot find class or module with type name '$typename'
                               |full type string: '$stpe'""".stripMargin
 
@@ -74,7 +74,7 @@ package object internal {
             }
             val tycon = sym.asType.toTypeConstructor
             appliedType(tycon, appliedTypeArgs.map(starg => typeFromString(mirror, starg.toString)))
-          case _ =>
+          case None =>
             sys.error(s"fatal: cannot unpickle $stpe")
         }
       typeFromStringCache(stpe) = result

--- a/core/src/main/scala/scala/pickling/json/JSONPickleFormat.scala
+++ b/core/src/main/scala/scala/pickling/json/JSONPickleFormat.scala
@@ -227,6 +227,7 @@ package json {
             case JSONObject(fields) if fields.contains("$ref") => FastTypeTag.Ref.key
             case JSONObject(fields) if fields.contains("$type") => fields("$type").asInstanceOf[String]
             case JSONObject(fields) => throw new PicklingException(s"Logic pickling error:  Could not find a type tag, and no elided type was hinted: ${fields}")
+            case value => throw new PicklingException(s"Logic pickling error:  Could not find a type tag on primitive, and no elided type was hinted: $value")
           }
         }
       }

--- a/core/src/main/scala/scala/pickling/pickler/Any.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Any.scala
@@ -12,4 +12,19 @@ trait AnyUnpicklers {
     }
     def tag: FastTypeTag[Any] = FastTypeTag[Any]
   }
+  // Note this is NOT implicit.  This is to be used when constructing picklers for unknown type parameters (e.g.
+  // when attempting to lookup runtime handlers).
+  val anyPickler: Pickler[Any] = new Pickler[Any] {
+    override def pickle(picklee: Any, builder: PBuilder): Unit = {
+      // Here we just look up the pickler.
+      val clazz = picklee.getClass
+      val classLoader = this.getClass.getClassLoader
+      internal.GRL.lock()
+      val tag = try FastTypeTag.mkRaw(clazz, scala.reflect.runtime.universe.runtimeMirror(classLoader))
+                finally internal.GRL.unlock()
+      val p = internal.currentRuntime.picklers.genPickler(classLoader, clazz, tag)
+      p.asInstanceOf[Pickler[Any]].pickle(picklee, builder)
+    }
+    override def tag: FastTypeTag[Any] = FastTypeTag[Any]
+  }
 }

--- a/core/src/main/scala/scala/pickling/pickler/Any.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Any.scala
@@ -1,30 +1,34 @@
 package scala.pickling
 package pickler
 
+/** An pickler for "Any" value (will look up pickler at runtime, or generate it. */
+object AnyPickler extends Pickler[Any] {
+  override def pickle(picklee: Any, builder: PBuilder): Unit = {
+    // Here we just look up the pickler.
+    val clazz = picklee.getClass
+    val classLoader = this.getClass.getClassLoader
+    internal.GRL.lock()
+    val tag = try FastTypeTag.mkRaw(clazz, scala.reflect.runtime.universe.runtimeMirror(classLoader))
+    finally internal.GRL.unlock()
+    val p = internal.currentRuntime.picklers.genPickler(classLoader, clazz, tag)
+    p.asInstanceOf[Pickler[Any]].pickle(picklee, builder)
+  }
+  override def tag: FastTypeTag[Any] = FastTypeTag[Any]
+  override def toString = "AnyPickler"
+}
+/** An unpickler for "Any" value (will look up unpickler at runtime, or generate it. */
+object AnyUnpickler extends Unpickler[Any] {
+  def unpickle(tag: String, reader: PReader): Any = {
+    val actualUnpickler = internal.currentRuntime.picklers.genUnpickler(scala.reflect.runtime.currentMirror, tag)
+    actualUnpickler.unpickle(tag, reader)
+  }
+  def tag: FastTypeTag[Any] = FastTypeTag[Any]
+  override def toString = "AnyUnPickler"
+}
+
 /** Attempts to unpickle Any by looking up registered unpicklers using `currentMirror`.
  */
 trait AnyUnpicklers {
   // Any
-  implicit val anyUnpickler: Unpickler[Any] = new Unpickler[Any] {
-    def unpickle(tag: String, reader: PReader): Any = {
-      val actualUnpickler = internal.currentRuntime.picklers.genUnpickler(scala.reflect.runtime.currentMirror, tag)
-      actualUnpickler.unpickle(tag, reader)
-    }
-    def tag: FastTypeTag[Any] = FastTypeTag[Any]
-  }
-  // Note this is NOT implicit.  This is to be used when constructing picklers for unknown type parameters (e.g.
-  // when attempting to lookup runtime handlers).
-  val anyPickler: Pickler[Any] = new Pickler[Any] {
-    override def pickle(picklee: Any, builder: PBuilder): Unit = {
-      // Here we just look up the pickler.
-      val clazz = picklee.getClass
-      val classLoader = this.getClass.getClassLoader
-      internal.GRL.lock()
-      val tag = try FastTypeTag.mkRaw(clazz, scala.reflect.runtime.universe.runtimeMirror(classLoader))
-                finally internal.GRL.unlock()
-      val p = internal.currentRuntime.picklers.genPickler(classLoader, clazz, tag)
-      p.asInstanceOf[Pickler[Any]].pickle(picklee, builder)
-    }
-    override def tag: FastTypeTag[Any] = FastTypeTag[Any]
-  }
+  implicit val anyUnpickler: Unpickler[Any] = AnyUnpickler
 }

--- a/core/src/main/scala/scala/pickling/pickler/ArrayBuffer.scala
+++ b/core/src/main/scala/scala/pickling/pickler/ArrayBuffer.scala
@@ -5,6 +5,7 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.ArrayBuffer
 
 trait ArrayBufferPicklers {
+  // TODO(jsuereth) - Add pickler generator
   implicit def arrayBufferPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[ArrayBuffer[T]], cbf: CanBuildFrom[ArrayBuffer[T], T, ArrayBuffer[T]]):
     Pickler[ArrayBuffer[T]] with Unpickler[ArrayBuffer[T]] =

--- a/core/src/main/scala/scala/pickling/pickler/Date.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Date.scala
@@ -5,6 +5,7 @@ import java.util.{Date, TimeZone}
 import java.text.SimpleDateFormat
 
 trait DatePicklers extends PrimitivePicklers {
+  // TODO(jsuereth) - Register runtime pickler.
   implicit val datePickler: Pickler[Date] with Unpickler[Date] =
   new AbstractPicklerUnpickler[Date] {
     private val dateFormatTemplate = {

--- a/core/src/main/scala/scala/pickling/pickler/Either.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Either.scala
@@ -3,7 +3,7 @@ package pickler
 
 /** Picklers for either trait. */
 trait EitherPicklers {
-
+  // TODO(jsuereth) - Register pickler generators
 
   implicit def pickleLeft[L, R](implicit lp: Pickler[L], t: FastTypeTag[Left[L,R]]): Pickler[Left[L, R]] =
      new AbstractPickler[Left[L, R]] {

--- a/core/src/main/scala/scala/pickling/pickler/Iterable.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Iterable.scala
@@ -59,7 +59,7 @@ object TravPickler {
       else currentRuntime.picklers.lookupPickler(elementType.key).getOrElse(
         throw new PicklingException(s"Cannnot generate a pickler/unpickler for $tpe, cannot find a pickler for $elementType"))
     val elemUnpickler =
-      if(elementType.key == ANY_TAG.key) AllPicklers.anyUnpickler
+      if(elementType.key == ANY_TAG.key) AnyUnpickler
       else currentRuntime.picklers.lookupUnpickler(elementType.key).getOrElse(
         throw new PicklingException(s"Cannnot generate a pickler/unpickler for $tpe, cannot find an unpickler for $elementType"))
     val colTag = FastTypeTag.apply(currentMirror, tpe.toString)

--- a/core/src/main/scala/scala/pickling/pickler/Iterable.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Iterable.scala
@@ -21,12 +21,9 @@ trait IterablePicklers {
       TravPickler.generate(implicitly[CanBuildFrom[List[Any], Any, List[Any]]], identity[List[Any]]) { tpe =>
         TravPickler.oneArgumentTagExtractor(tpe)
       } _
-    currentRuntime.picklers.registerPicklerGenerator("scala.collection.immutable.List", generator)
-    currentRuntime.picklers.registerUnpicklerGenerator("scala.collection.immutable.List", generator)
-    currentRuntime.picklers.registerPicklerGenerator("scala.collection.immutable.$colon$colon", generator)
-    currentRuntime.picklers.registerUnpicklerGenerator("scala.collection.immutable.$colon$colon", generator)
-    currentRuntime.picklers.registerPicklerGenerator("scala.collection.immutable.Nil.type", generator)
-    currentRuntime.picklers.registerUnpicklerGenerator("scala.collection.immutable.Nil.type", generator)
+    currentRuntime.picklers.registerPicklerUnpicklerGenerator("scala.collection.immutable.List", generator)
+    currentRuntime.picklers.registerPicklerUnpicklerGenerator("scala.collection.immutable.$colon$colon", generator)
+    currentRuntime.picklers.registerPicklerUnpicklerGenerator("scala.collection.immutable.Nil.type", generator)
   }
 }
 
@@ -43,7 +40,7 @@ object TravPickler {
   }
 
   /** Creates a pickling generator that can be registered at runtime. */
-  def generate[T, C](cbf: CanBuildFrom[C,T,C], asTraversable: C => Traversable[_])(elementTagExtractor: AppliedType => FastTypeTag[T])(tpe: AppliedType): AbstractPicklerUnpickler[_] = {
+  def generate[T, C](cbf: CanBuildFrom[C,T,C], asTraversable: C => Traversable[_])(elementTagExtractor: AppliedType => FastTypeTag[T])(tpe: AppliedType): AbstractPicklerUnpickler[C] = {
     // TODO - we need to construct all the things we need from the tag to create a pickler/unpickler
     val elementType = elementTagExtractor(tpe)
     // TODO - These any pickler.unpicklers should be passed in.

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
@@ -7,6 +7,7 @@ import java.math.BigDecimal
   * Note; This currently serialzies as a string.
   */
 trait JavaBigDecimalPicklers extends PrimitivePicklers {
+  // TODO(jsuereth) - Register runtime picklers
   implicit val javaBigDecimalPickler:
     Pickler[BigDecimal] with Unpickler[BigDecimal] = new AbstractPicklerUnpickler[BigDecimal] {
     def tag = FastTypeTag[BigDecimal]

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
@@ -7,7 +7,6 @@ import java.math.BigDecimal
   * Note; This currently serialzies as a string.
   */
 trait JavaBigDecimalPicklers extends PrimitivePicklers {
-  // TODO(jsuereth) - Register runtime picklers
   implicit val javaBigDecimalPickler:
     Pickler[BigDecimal] with Unpickler[BigDecimal] = new AbstractPicklerUnpickler[BigDecimal] {
     def tag = FastTypeTag[BigDecimal]
@@ -26,4 +25,7 @@ trait JavaBigDecimalPicklers extends PrimitivePicklers {
       new BigDecimal(result.asInstanceOf[String])
     }
   }
+
+  // TODO - Figure out if we should somehow have these all registered somewhere else rather than take the hit at construction time.
+  internal.currentRuntime.picklers.registerPicklerUnpickler(javaBigDecimalPickler.tag.key, javaBigDecimalPickler)
 }

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
@@ -6,6 +6,7 @@ import java.math.BigInteger
 
 /** This contains implicits which can serialize java.math.BigInteger values. */
 trait JavaBigIntegerPicklers extends PrimitivePicklers {
+  // TODO(jsuereth) - Register runtime picklers
   implicit val javaBigIntegerPickler:
     Pickler[BigInteger] with Unpickler[BigInteger] = new AbstractPicklerUnpickler[BigInteger] {
     def tag = FastTypeTag[BigInteger]

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
@@ -26,5 +26,8 @@ trait JavaBigIntegerPicklers extends PrimitivePicklers {
       val result = stringPickler.unpickleEntry(reader1)
       new BigInteger(result.asInstanceOf[String])
     }
-  } 
+  }
+
+  // TODO - Figure out if we should somehow have these all registered somewhere else rather than take the hit at construction time.
+  internal.currentRuntime.picklers.registerPicklerUnpickler(javaBigIntegerPickler.tag.key, javaBigIntegerPickler)
 }

--- a/core/src/main/scala/scala/pickling/pickler/JavaUUIDPickler.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaUUIDPickler.scala
@@ -4,7 +4,7 @@ package pickler
 import java.util.UUID
 
 trait JavaUUIDPicklers extends PrimitivePicklers {
-  // TODO(jsuereth) - Register runtime picklers
+
   implicit val javaUUIDPickler:
     Pickler[UUID] with Unpickler[UUID] = new AbstractPicklerUnpickler[UUID] {
     def tag = FastTypeTag[UUID]
@@ -37,4 +37,5 @@ trait JavaUUIDPicklers extends PrimitivePicklers {
       new java.util.UUID(msb, lsb)
     }
   }
+  internal.currentRuntime.picklers.registerPicklerUnpickler(javaUUIDPickler.tag.key, javaUUIDPickler)
 }

--- a/core/src/main/scala/scala/pickling/pickler/JavaUUIDPickler.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaUUIDPickler.scala
@@ -4,6 +4,7 @@ package pickler
 import java.util.UUID
 
 trait JavaUUIDPicklers extends PrimitivePicklers {
+  // TODO(jsuereth) - Register runtime picklers
   implicit val javaUUIDPickler:
     Pickler[UUID] with Unpickler[UUID] = new AbstractPicklerUnpickler[UUID] {
     def tag = FastTypeTag[UUID]

--- a/core/src/main/scala/scala/pickling/pickler/Map.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Map.scala
@@ -3,20 +3,53 @@ package pickler
 
 import scala.collection.generic.CanBuildFrom
 import scala.collection.{ immutable, mutable }
+import scala.pickling.internal._
 
-// TODO(jsuereth) - Register runtime pickler generators
+object MapPicklerHelper {
+  def tupleTagExtractor[T,U](tpe: AppliedType): FastTypeTag[(T, U)] = {
+    tpe.typeargs match {
+      case List(one, two) => FastTypeTag.apply(currentMirror, s"scala.Tuple2[${one.toString},${two.toString}]").asInstanceOf[FastTypeTag[(T, U)]]
+      // Note: This is what we do to handle
+      case List() => FastTypeTag.apply(currentMirror,"scala.Tuple2").asInstanceOf[FastTypeTag[(T,U)]]
+      case x => throw new PicklingException(s"Error, expected one type argument  on $tpe, found: $x")
+    }
+  }
+}
 
 trait MapPicklers {
   implicit def mapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: Pickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[Map[K, V]], cbf: CanBuildFrom[Map[K, V], (K, V), Map[K, V]]): Pickler[Map[K, V]] with Unpickler[Map[K, V]] =
     MapPickler[K, V, Map]
+
+  locally {
+    val generator =
+      TravPickler.generate[(Any, Any), Map[Any, Any]](implicitly[CanBuildFrom[Map[Any, Any], (Any, Any), Map[Any,Any]]], identity[Map[Any, Any]]) { tpe =>
+        MapPicklerHelper.tupleTagExtractor(tpe)
+      } _
+    currentRuntime.picklers.registerPicklerUnpicklerGenerator("scala.collection.immutable.Map", generator)
+    currentRuntime.picklers.registerPicklerUnpicklerGenerator("scala.collection.immutable.Map.Map1", generator)
+    currentRuntime.picklers.registerPicklerUnpicklerGenerator("scala.collection.immutable.Map.Map2", generator)
+    currentRuntime.picklers.registerPicklerUnpicklerGenerator("scala.collection.immutable.Map.Map3", generator)
+    currentRuntime.picklers.registerPicklerUnpicklerGenerator("scala.collection.immutable.Map.Map4", generator)
+    currentRuntime.picklers.registerPicklerUnpicklerGenerator("scala.collection.immutable.HashMap.HashTrieMap", generator)
+  }
 }
 
 trait ImmutableSortedMapPicklers {
   implicit def immutableSortedMapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: Pickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[immutable.SortedMap[K, V]], cbf: CanBuildFrom[immutable.SortedMap[K, V], (K, V), immutable.SortedMap[K, V]]): Pickler[immutable.SortedMap[K, V]] with Unpickler[immutable.SortedMap[K, V]] =
     MapPickler[K, V, immutable.SortedMap]
+
+  // TODO - SortedMap runtime generation involves using a specialized pickler that can remember the ordering of elements.  Currently our pickler does not do that.
 }
 
 trait MutableMapPicklers {
   implicit def mutableMapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: Pickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[mutable.Map[K, V]], cbf: CanBuildFrom[mutable.Map[K, V], (K, V), mutable.Map[K, V]]): Pickler[mutable.Map[K, V]] with Unpickler[mutable.Map[K, V]] =
     MapPickler[K, V, mutable.Map]
+
+  locally {
+    val generator =
+      TravPickler.generate[(Any, Any), mutable.Map[Any, Any]](implicitly[CanBuildFrom[mutable.Map[Any, Any], (Any, Any), mutable.Map[Any,Any]]], identity[mutable.Map[Any, Any]]) { tpe =>
+        MapPicklerHelper.tupleTagExtractor(tpe)
+      } _
+    currentRuntime.picklers.registerPicklerUnpicklerGenerator("scala.collection.mutable.Map", generator)
+  }
 }

--- a/core/src/main/scala/scala/pickling/pickler/Map.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Map.scala
@@ -4,6 +4,8 @@ package pickler
 import scala.collection.generic.CanBuildFrom
 import scala.collection.{ immutable, mutable }
 
+// TODO(jsuereth) - Register runtime pickler generators
+
 trait MapPicklers {
   implicit def mapPickler[K: FastTypeTag, V: FastTypeTag](implicit elemPickler: Pickler[(K, V)], elemUnpickler: Unpickler[(K, V)], pairTag: FastTypeTag[(K, V)], collTag: FastTypeTag[Map[K, V]], cbf: CanBuildFrom[Map[K, V], (K, V), Map[K, V]]): Pickler[Map[K, V]] with Unpickler[Map[K, V]] =
     MapPickler[K, V, Map]

--- a/core/src/main/scala/scala/pickling/pickler/Seq.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Seq.scala
@@ -4,6 +4,8 @@ package pickler
 import scala.collection.generic.CanBuildFrom
 import scala.collection.{ IndexedSeq, LinearSeq }
 
+// TODO(jsuereth) - Register runtime pickler generators
+
 trait SeqPicklers {
   implicit def seqPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[Seq[T]], cbf: CanBuildFrom[Seq[T], T, Seq[T]]): Pickler[Seq[T]] with Unpickler[Seq[T]] =

--- a/core/src/main/scala/scala/pickling/pickler/Set.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Set.scala
@@ -4,6 +4,8 @@ package pickler
 import scala.collection.generic.CanBuildFrom
 import scala.collection.{ immutable, mutable }
 
+// TODO(jsuereth) - Register runtime pickler generators
+
 trait SetPicklers {
   implicit def setPickler[T: FastTypeTag](implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
     collTag: FastTypeTag[Set[T]], cbf: CanBuildFrom[Set[T], T, Set[T]]): Pickler[Set[T]] with Unpickler[Set[T]] =

--- a/core/src/main/scala/scala/pickling/pickler/Vector.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Vector.scala
@@ -3,6 +3,8 @@ package pickler
 
 import scala.collection.generic.CanBuildFrom
 
+// TODO(jsuereth) - Register runtime pickler generators
+
 trait VectorPicklers {
   implicit def vectorPickler[T: FastTypeTag](implicit elemPickler: Pickler[T],
     elemUnpickler: Unpickler[T], collTag: FastTypeTag[Vector[T]], cbf: CanBuildFrom[Vector[T], T, Vector[T]]):

--- a/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
@@ -34,6 +34,9 @@ trait PicklerRegistry {
     * @param typeConstructorKey  The type constructor.  e.g. "scala.List" for something that can make scala.List[A] picklers.
     * @param generator  A function which takes an applied type string (your type + arguments) and returns a pickler for
     *                   this type.
+    *                   Note:  it is possible for the type arguments to be an empty set.  This is the case if we are
+    *                   trying to manually inspect an object at runtime to deterimine its type, and we do not know what
+    *                   the arguments are.  You can treat this case as 'existential' arguments.
     */
   def registerPicklerGenerator(typeConstructorKey: String, generator: AppliedType => Pickler[_]): Unit
   /** Registers a function which can generate picklers for a given type constructor.

--- a/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
@@ -1,6 +1,7 @@
 package scala.pickling
 package spi
 
+import scala.pickling.internal.AppliedType
 import scala.reflect.runtime.universe.Mirror
 
 /** A registry for looking up (and possibly coding on the fly) picklers by tag.
@@ -14,11 +15,34 @@ trait PicklerRegistry {
   def genUnpickler(mirror: Mirror, tagKey: String)(implicit share: refs.Share): Unpickler[_]
   /** Looks up a Pickler or generates one. */
   def genPickler(classLoader: ClassLoader, clazz: Class[_], tag: FastTypeTag[_])(implicit share: refs.Share): Pickler[_]
+
+
   /** Checks the existince of an unpickler. */
   def lookupUnpickler(key: String): Option[Unpickler[_]]
+  /** Looks for a pickler with the given FastTypeTag string. */
+  def lookupPickler(key: String): Option[Pickler[_]]
+
+
   /** Registers a pickler with this registry for future use. */
   def registerPickler(key: String, p: Pickler[_]): Unit  // TODO - Return old pickler if one existed?
   /** Registers an unpickler with this registry for future use. */
   def registerUnpickler(key: String, p: Unpickler[_]): Unit
+
+
+  /** Registers a function which can generate picklers for a given type constructor.
+    *
+    * @param typeConstructorKey  The type constructor.  e.g. "scala.List" for something that can make scala.List[A] picklers.
+    * @param generator  A function which takes an applied type string (your type + arguments) and returns a pickler for
+    *                   this type.
+    */
+  def registerPicklerGenerator(typeConstructorKey: String, generator: AppliedType => Pickler[_]): Unit
+  /** Registers a function which can generate picklers for a given type constructor.
+    *
+    * @param typeConstructorKey  The type constructor.  e.g. "scala.List" for something that can make scala.List[A] picklers.
+    * @param generator  A function which takes an applied type string (your type + arguments) and returns a pickler for
+    *                   this type.
+    */
+  def registerUnpicklerGenerator(typeConstructorKey: String, generator: AppliedType => Unpickler[_]): Unit
+
   // TODO - Some kind of clean or inspect what we have?
 }

--- a/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
@@ -9,24 +9,59 @@ import scala.reflect.runtime.universe.Mirror
   * All methods are threadsafe.
   */
 trait PicklerRegistry {
-  // TODO - Do we need lookup*s w/ the gen*s?
+  // TODO(jsuereth) - We should remove the `gen` traits here and hide generation behind the lookup methods.
 
-  /** Looks up the registered unpickler using the provided tagKey. */
+  /** Looks up the registered unpickler using the provided tagKey.
+    *
+    * If there are no registered picklers or pickler-generators, then we instead attempt to generate the pickler using
+    * the passed in information.
+    *
+    * TODO(jsuereth) - This should use classLoader just like genPickler.  No reason to mix Java/Scala reflection.
+    *
+    * @param mirror  The scala mirror (classloader/symbolloader) we use to generate the unpickler.
+    * @param tagKey The full tag of the type, which may or may not include type parameters.
+    */
   def genUnpickler(mirror: Mirror, tagKey: String)(implicit share: refs.Share): Unpickler[_]
-  /** Looks up a Pickler or generates one. */
+  /** Looks up a Pickler for the given tag.  If none is found, then we attempt to generate one.
+    *
+    * @param classLoader The classloader to use when reflecting over the pickled class.
+    * @param clazz The clazz we need to pickle.
+    * @param tag The full tag of the type we're pickling, which may or may not include type parameters.
+    */
   def genPickler(classLoader: ClassLoader, clazz: Class[_], tag: FastTypeTag[_])(implicit share: refs.Share): Pickler[_]
 
 
-  /** Checks the existince of an unpickler. */
+  /** Checks the existince of an unpickler.
+    *
+    * This will also check any registered generator functions.
+    */
   def lookupUnpickler(key: String): Option[Unpickler[_]]
-  /** Looks for a pickler with the given FastTypeTag string. */
+  /** Looks for a pickler with the given FastTypeTag string.
+    *
+    * This will also check any registered generator functions.
+    */
   def lookupPickler(key: String): Option[Pickler[_]]
 
 
-  /** Registers a pickler with this registry for future use. */
-  def registerPickler(key: String, p: Pickler[_]): Unit  // TODO - Return old pickler if one existed?
-  /** Registers an unpickler with this registry for future use. */
-  def registerUnpickler(key: String, p: Unpickler[_]): Unit
+  /** Registers a pickler with this registry for future use.
+    *
+    * @param key  The type key for the pickler. Note: In reflective scenarios this may not include type parameters.
+    *             In those situations, the pickler should be able to handle arbitrary (existential) type parameters.
+    * @param p  The pickler to register.
+    */
+  def registerPickler[T](key: String, p: Pickler[T]): Unit  // TODO - Return old pickler if one existed?
+  /** Registers an unpickler with this registry for future use.
+    * @param key  The type key for the unpickler. Note: In reflective scenarios this may not include type parameters.
+    *             In those situations, the unpickler should be able to handle arbitrary (existential) type parameters.
+    * @param p  The unpickler to register.
+    */
+  def registerUnpickler[T](key: String, p: Unpickler[T]): Unit
+  /** Registers a pickler and unpickler for a type with this registry for future use.
+    * @param key  The type key for the pickler. Note: In reflective scenarios this may not include type parameters.
+    *             In those situations, the pickler should be able to handle arbitrary (existential) type parameters.
+    * @param p  The unpickler to register.
+    */
+  def registerPicklerUnpickler[T](key: String, p: (Pickler[T] with Unpickler[T])): Unit  // TODO - Return old pickler if one existed?
 
 
   /** Registers a function which can generate picklers for a given type constructor.
@@ -38,14 +73,20 @@ trait PicklerRegistry {
     *                   trying to manually inspect an object at runtime to deterimine its type, and we do not know what
     *                   the arguments are.  You can treat this case as 'existential' arguments.
     */
-  def registerPicklerGenerator(typeConstructorKey: String, generator: AppliedType => Pickler[_]): Unit
+  def registerPicklerGenerator[T](typeConstructorKey: String, generator: AppliedType => Pickler[T]): Unit
   /** Registers a function which can generate picklers for a given type constructor.
     *
     * @param typeConstructorKey  The type constructor.  e.g. "scala.List" for something that can make scala.List[A] picklers.
     * @param generator  A function which takes an applied type string (your type + arguments) and returns a pickler for
     *                   this type.
     */
-  def registerUnpicklerGenerator(typeConstructorKey: String, generator: AppliedType => Unpickler[_]): Unit
-
+  def registerUnpicklerGenerator[T](typeConstructorKey: String, generator: AppliedType => Unpickler[T]): Unit
+  /** Registers a function which can generate picklers for a given type constructor.
+    *
+    * @param typeConstructorKey  The type constructor.  e.g. "scala.List" for something that can make scala.List[A] picklers.
+    * @param generator  A function which takes an applied type string (your type + arguments) and returns a pickler for
+    *                   this type.
+    */
+  def registerPicklerUnpicklerGenerator[T](typeConstructorKey: String, generator: AppliedType => (Pickler[T] with Unpickler[T])): Unit
   // TODO - Some kind of clean or inspect what we have?
 }

--- a/core/src/test/scala/pickling/run/externalizable-mapstatus.scala
+++ b/core/src/test/scala/pickling/run/externalizable-mapstatus.scala
@@ -148,12 +148,13 @@ class MapStatus(var location: BlockManagerId, var compressedSizes: Array[Byte])
 }
 
 class MapStatusTest extends FunSuite {
-  def register[T: ClassTag: Pickler: Unpickler](): Unit = {
+  def register[T: ClassTag: Pickler: Unpickler : FastTypeTag](): Unit = {
     val clazz = classTag[T].runtimeClass
     val p = implicitly[Pickler[T]]
     val up = implicitly[Unpickler[T]]
-    internal.currentRuntime.picklers.registerPickler(clazz.getName(), p)
-    internal.currentRuntime.picklers.registerUnpickler(clazz.getName, up)
+    val tagKey = implicitly[FastTypeTag[T]].key
+    internal.currentRuntime.picklers.registerPickler(tagKey, p)
+    internal.currentRuntime.picklers.registerUnpickler(tagKey, up)
   }
 
   register[MapStatus]

--- a/core/src/test/scala/pickling/run/wrapped-array.scala
+++ b/core/src/test/scala/pickling/run/wrapped-array.scala
@@ -56,8 +56,8 @@ class WrappedArrayTest extends FunSuite {
       new WrappedArray.ofRef(newArray)
     }
   }
-
-  internal.currentRuntime.picklers.registerPickler("scala.collection.mutable.WrappedArray$ofRef", mkAnyRefWrappedArrayPickler)
+  // TODO - This is kind of a hack because we don't really know the full tag, and we're tagging the instance with a partial tag.
+  internal.currentRuntime.picklers.registerPickler("scala.collection.mutable.WrappedArray.ofRef", mkAnyRefWrappedArrayPickler)
   internal.currentRuntime.picklers.registerUnpickler("scala.collection.mutable.WrappedArray.ofRef[java.lang.Object]", mkAnyRefWrappedArrayPickler)
 
   test("main") {


### PR DESCRIPTION
Example Usage:

```
scala> import scala.pickling._, json._, Defaults._
import scala.pickling._
import json._
import Defaults._

scala> Map(1->2, 2->3).pickle
res1: scala.pickling.json.pickleFormat.PickleType =
JSONPickle({
  "$type": "scala.collection.immutable.Map[scala.Int,scala.Int]",
  "elems": [
    {
    "$type": "scala.Tuple2[scala.Int,scala.Int]",
    "_1": 1,
    "_2": 2
  },
    {
    "$type": "scala.Tuple2[scala.Int,scala.Int]",
    "_1": 2,
    "_2": 3
  }
  ]
})

scala> res1.unpickle[Any]
res2: Any = Map(1 -> 2, 2 -> 3)
```

This would have been problematic before with runtime unpicklers because we were NOT keeping any elided tags around, and we'd throw an exception trying to unpickle `Any` when we hit _1 or _2.

Additionally, we now have a more optimised List serializer:

``` scala
scala> (List(1,2,3): Any).pickle
res3: scala.pickling.json.pickleFormat.PickleType =
JSONPickle({
  "$type": "scala.collection.immutable.$colon$colon",
  "elems": [
    {
    "$type": "scala.Int",
    "value": 1
  },
    {
    "$type": "scala.Int",
    "value": 2
  },
    {
    "$type": "scala.Int",
    "value": 3
  }
  ]
})
```

Additonally, this PR attempts to provide a mechanism whereby a pickler for a type T[_,_,...] can be constructed such that it will use the PicklerRegistry to look up additoinally necessary picklers at runtime, allowing for a more generic custom pickler to interact with user types.  This removes the need for special casing of the Tuple2 class, and is how we fixed the issue with List's runtime serialzier.  Generally should help provide more unity between custom picklers AND runtime picklers.

Review by @phaller @eed3si9n 

Fixes #368
