### PR TITLE
Add a new mechanism to configure pickler generators.

### DIFF
--- a/core/src/main/scala/scala/pickling/Macros.scala
+++ b/core/src/main/scala/scala/pickling/Macros.scala
@@ -10,6 +10,9 @@ trait TypeAnalysis extends Macro {
   def isStaticOnly: Boolean =
     c.inferImplicitValue(typeOf[IsStaticOnly]) != EmptyTree
 
+  def configOption(t: Type): Boolean =
+    c.inferImplicitValue(t) != EmptyTree
+
   def isCaseClass(sym: TypeSymbol): Boolean =
     sym.isClass && sym.asClass.isCaseClass
 

--- a/core/src/main/scala/scala/pickling/generator/CaseClassPickling.scala
+++ b/core/src/main/scala/scala/pickling/generator/CaseClassPickling.scala
@@ -8,7 +8,7 @@ package generator
   * This ONLY handles case-class types, it will not handle ADTS, but can generate code for non-final case classes.
   *
   */
-class CaseClassPickling(val allowReflection: Boolean) extends PicklingAlgorithm {
+class CaseClassPickling(val allowReflection: Boolean, val careAboutSubclasses: Boolean) extends PicklingAlgorithm {
   case class FieldInfo(name: String, sym: IrMethod)
   case class CaseClassInfo(constructor: IrConstructor, fields: Seq[FieldInfo])
 
@@ -125,7 +125,7 @@ class CaseClassPickling(val allowReflection: Boolean) extends PicklingAlgorithm 
     // Scala modules are pickled differently, so we have to explicitly ignore `case object`
     if(tpe.isCaseClass && !tpe.isScalaModule) {
       val behavior = (checkConstructorImpl(tpe, logger) join checkFactoryImpl(tpe, logger))
-      if(!tpe.isFinal) {
+      if(careAboutSubclasses && !tpe.isFinal) {
         // TODO - We need a different flag to say if we'll use runtime picklers *VS* reflection. The two features are not the same.
         tpe.closedSubclasses match {
           case scala.util.Success(subs) =>

--- a/core/src/main/scala/scala/pickling/generator/opts/package.scala
+++ b/core/src/main/scala/scala/pickling/generator/opts/package.scala
@@ -1,0 +1,11 @@
+package scala.pickling.generator
+
+trait IsIgnoreCaseClassSubclasses
+
+/**
+ * This gives us all of our generator options.
+ */
+package object opts {
+  implicit object ignoreCaseClassSubclasses extends IsIgnoreCaseClassSubclasses
+
+}

--- a/core/src/test/scala/scala/pickling/generator/CaseClassGeneratorTest.scala
+++ b/core/src/test/scala/scala/pickling/generator/CaseClassGeneratorTest.scala
@@ -110,6 +110,21 @@ class CaseClassGeneratorTest extends FunSuite {
     val y1 = x1.pickle.unpickle[OpenCaseClass]
     assert(x1 == y1)
   }
+
+  test("ignoreSubclasses") {
+    import generator.opts.ignoreCaseClassSubclasses
+    import static._
+    case class Other(x: Int)
+    implicit val pu = {
+      PicklingMacros.genPicklerUnpickler[OpenCaseClass]
+    }
+    implicit val pu2 = PicklingMacros.genPicklerUnpickler[Other]
+    val x = OpenCaseClass(1)
+    // Because we ignore subclasses, we shouldn't freak about subclass tags, because we ignore them. Only the
+    // "shape" of the pickle should matter.
+    val y = x.pickle.unpickle[Other]
+    assert(x.x == y.x)
+  }
 }
 
 // Case 1 - empty


### PR DESCRIPTION
- Createa  new `opts` package where you can import generator options
- Create helper methods to look up opts
- Create first (necessary) option for case-class pickling to ignore subclasses.
- Add teh apple/bannana subclass test to see if options work.

This is a necessary change for sbt-serialziation with the new picklers.

Review by @eed3si9n  cc @phaller 
