### PR TITLE
We can now, at least, compile for Scala 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,11 @@ val buildVersion = "0.10.2-SNAPSHOT"
 def commonSettings = Seq(
   version in ThisBuild := buildVersion,
   scalaVersion := Util.buildScalaVersion,
+  crossScalaVersions := Util.buildScalaVersions,
+  scalacOptions in (Test, compile) ++= (scalaBinaryVersion.value match {
+    case "2.10" => Seq("-Xmax-classfile-name", "254")
+    case _ => Seq()
+  }),
   organization in ThisBuild := "org.scala-lang.modules",
   organizationName in ThisBuild := "LAMP/EPFL",
   organizationHomepage in ThisBuild := Some(url("http://lamp.epfl.ch")),

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -2,7 +2,8 @@ import sbt._
 import Keys._
 
 object Util {
-  val buildScalaVersion = System.getProperty("scala.version", "2.11.7")
+  val buildScalaVersion = System.getProperty("scala.version", "2.10.4")
+  val buildScalaVersions = Seq("2.11.7", "2.10.4")
   val javaVersion       = System.getProperty("java.version")
 
   def loadCredentials(): List[Credentials] = {


### PR DESCRIPTION
Review by @phaller or @eed3si9n 

This lets us issue the 0.11.0-M1 when we're ready.  It's fully usable but some odd test failure relating to some odd type system fun.
