### PR TITLE
TODO cleanups

### DIFF
--- a/core/src/main/scala/scala/pickling/Ops.scala
+++ b/core/src/main/scala/scala/pickling/Ops.scala
@@ -23,7 +23,10 @@ final case class UnpickleOps(val thePickle: Pickle) {
     functions.unpickle(thePickle.asInstanceOf[format.PickleType])(unpickler, format)
 }
 
-/** A layer of pickling cake that can "lift" picklable types to have the core pickle operations. */
+/** A layer of protocol stack that can "lift" picklable types to have the core pickle operations.
+  *
+  * For example usage, see [[scala.pickling.Defaults]]
+  */
 trait Ops {
   implicit def pickleOps[T](picklee: T): PickleOps[T] = PickleOps(picklee)
   implicit def unpickleOps(thePickle: Pickle): UnpickleOps = UnpickleOps(thePickle)

--- a/core/src/main/scala/scala/pickling/Ops.scala
+++ b/core/src/main/scala/scala/pickling/Ops.scala
@@ -23,6 +23,7 @@ final case class UnpickleOps(val thePickle: Pickle) {
     functions.unpickle(thePickle.asInstanceOf[format.PickleType])(unpickler, format)
 }
 
+/** A layer of pickling cake that can "lift" picklable types to have the core pickle operations. */
 trait Ops {
   implicit def pickleOps[T](picklee: T): PickleOps[T] = PickleOps(picklee)
   implicit def unpickleOps(thePickle: Pickle): UnpickleOps = UnpickleOps(thePickle)

--- a/core/src/main/scala/scala/pickling/PBuilderReader.scala
+++ b/core/src/main/scala/scala/pickling/PBuilderReader.scala
@@ -3,7 +3,34 @@ package scala.pickling
 import scala.language.experimental.macros
 
 import scala.reflect.runtime.universe._
-// TODO - Document this, specifically what pinHints means.
+
+/**
+ * Hintable defines the interface used between picklers and formats to "aide' in creating clean/efficient formats.
+ *
+ *
+ * The FULL features picklers allow:
+ * - eliding statically known types
+ * - structural sharing of data
+ * - possible binary size optimizations (using jvm sizes)
+ *
+ * Obviously not all picklers will use these mechanisms.
+ *
+ * ----
+ * === Size Optimization ===
+ * If a pickler/unpickler calls `hintKnownSize`, it's talking about a binary size of the following entry.
+ * ----
+ * === Type Optimization ===
+ * If a pickler/unpickler call `hintElidedType`, it's allowing the underlying format to 'drop' the forced storage of a
+ * type tag.
+ * ----
+ * === Structural Sharing ===
+ * If a pickler/unpickler calls `hintOid`, it's telling the underlying format that this particular pickler entry
+ * shares it structure with the same entry of that number.
+ *
+ * Currently, rather than using known tags, picklers assume a per-pickle ordinal associated with each entry.  This
+ * ordinal should be automatically tracked and restored.
+ *
+ */
 trait Hintable {
   /** Hints at the expected (byte) size of the entry we're about to write.. */
   def hintKnownSize(knownSize: Int): this.type

--- a/core/src/main/scala/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/scala/pickling/Pickler.scala
@@ -83,7 +83,7 @@ abstract class AbstractUnpickler[T] extends Unpickler[T]
 object Unpickler {
   def generate[T]: Unpickler[T] = macro generator.Compat.genUnpickler_impl[T]
 }
-/* Shim for java code (TODO - a good name for this.) */
+/* Shim for java code which wants to pickle/unpickle. */
 abstract class AbstractPicklerUnpickler[T] extends Pickler[T] with Unpickler[T]
 object PicklerUnpickler {
   def apply[T](p: Pickler[T], u: Unpickler[T]): AbstractPicklerUnpickler[T] = new DelegatingPicklerUnpickler(p, u)
@@ -100,6 +100,7 @@ object PicklerUnpickler {
   }
 }
 
+/** A pickler which will register itself with the runtime pickler registery. */
 abstract class AutoRegister[T: FastTypeTag](name: String) extends AbstractPicklerUnpickler[T] {
   val tag = implicitly[FastTypeTag[T]]
 

--- a/core/src/main/scala/scala/pickling/functions.scala
+++ b/core/src/main/scala/scala/pickling/functions.scala
@@ -19,9 +19,6 @@ object functions {
 
   // Note: this does NOT clear picklees.
   def pickleInto[T](picklee: T, builder: PBuilder)(implicit pickler: Pickler[T]): Unit = {
-    // TODO - BeginEntry/EndEntry needed?
-    // TODO - this hinting should be in the pickler, not here.  We need to understand
-    //        when we want to use this vs. something else, and avoid over-hinting everywhere.
     if (null == picklee) Defaults.nullPickler.pickle(null, builder)
     else pickler.pickle(picklee, builder)
   }

--- a/core/src/main/scala/scala/pickling/generator/AdtPickling.scala
+++ b/core/src/main/scala/scala/pickling/generator/AdtPickling.scala
@@ -3,7 +3,7 @@ package generator
 
 
 /** This algorithm isnpects symbols to determine if we have an abstract class with fully known sub-classes,
-  * in which case we delegate behavior to the subclasses.
+  * in which case we delegate all behavior to the subclasses.
   */
 private[pickling] object AdtPickling extends PicklingAlgorithm {
   /**
@@ -14,13 +14,10 @@ private[pickling] object AdtPickling extends PicklingAlgorithm {
       AlgorithmFailure(s"Cannot use ADT algorithm because $tpe is not abstract")
     } else tpe.closedSubclasses match {
       case scala.util.Failure(msgs) =>
-        // TODO - SHould we warn here, or collect errors for later?
         AlgorithmFailure(s"Could not determine if $tpe is closed for ADT generation:\n\t\t$msgs")
       case scala.util.Success(Seq()) =>
         AlgorithmFailure(s"Failed to create ADT pickler for $tpe.  Type is closed, but could not find subclasses.\n  You can use @directSubclasses to annotate known subclasses.")
       case scala.util.Success(subclasses) =>
-        // TODO - Should we check if we need to also serialize our own state, or delegate that to a different algorithm?
-        // TODO - Should we allow dynamic dispatch here (reflection)?
         val pickle = PickleBehavior(Seq(SubclassDispatch(subclasses, tpe)))
         val unpickle = UnpickleBehavior(Seq(SubclassUnpicklerDelegation(subclasses, tpe)))
         AlgorithmSucccess(PickleUnpickleImplementation(pickle, unpickle))

--- a/core/src/main/scala/scala/pickling/generator/Macros.scala
+++ b/core/src/main/scala/scala/pickling/generator/Macros.scala
@@ -1,7 +1,6 @@
 package scala.pickling
 package generator
 
-// TODO - move these into Pickler/Unpickler and replace the existing macros.
 private[pickling] object PicklingMacros {
   import scala.language.experimental.macros
   def genPickler[T]: Pickler[T] with Generated = macro scala.pickling.generator.Compat.genPickler_impl[T]
@@ -15,8 +14,10 @@ private[pickling] trait PicklingMacros extends Macro with SourceGenerator with T
   val handleCaseClassSubclasses = !configOption(typeOf[IsIgnoreCaseClassSubclasses])
   val generator =
     if(isStaticOnly) {
-      // TODO - should we consider externalizable "safe" or "static only" since we know it's externalizable at compile time?
-      PicklingAlgorithm.aggregate(Seq(new CaseClassPickling(allowReflection = false, careAboutSubclasses = handleCaseClassSubclasses), AdtPickling, ScalaSingleton))
+      PicklingAlgorithm.aggregate(Seq(
+        new CaseClassPickling(allowReflection = false, careAboutSubclasses = handleCaseClassSubclasses),
+        AdtPickling,
+        ScalaSingleton))
     } else {
       PicklingAlgorithm.aggregate(Seq(
         new CaseClassPickling(allowReflection = true, careAboutSubclasses = handleCaseClassSubclasses),

--- a/core/src/main/scala/scala/pickling/generator/WillRobinsonPickling.scala
+++ b/core/src/main/scala/scala/pickling/generator/WillRobinsonPickling.scala
@@ -12,8 +12,6 @@ private[pickling] object WillRobinsonPickling extends PicklingAlgorithm {
   private case class FieldInfo(setter: SetField, getter: GetField)
   // TODO - Constructor unification in the case-class generator is probably still useful here...
   private def allScalaField(tpe: IrClass, logger: AlgorithmLogger): Seq[FieldInfo] = {
-    // TODO - We find all these and hope it's ok
-    // TODO - We need this list to actually come from a recursive descent through the hierarchy for vars.
     val fields =
       // Note: For some reason, we sometimes see the same field twice, so we filter these out here.
       //       This is probably a bug somewhere.

--- a/core/src/main/scala/scala/pickling/generator/algorithms.scala
+++ b/core/src/main/scala/scala/pickling/generator/algorithms.scala
@@ -3,8 +3,6 @@ package generator
 
 import scala.reflect.api.Universe
 
-// TODO - These need logging messages.
-
 /** An interface so we can pass logging to these algorithms at runtime/during testing. */
 private[pickling] trait AlgorithmLogger {
   def warn(msg: String): Unit

--- a/core/src/main/scala/scala/pickling/generator/sourcegen.scala
+++ b/core/src/main/scala/scala/pickling/generator/sourcegen.scala
@@ -43,7 +43,6 @@ private[pickling]  trait SourceGenerator extends Macro with FastTypeTagMacros {
 
       x.getter match {
         case x: IrField =>
-          // TODO - handle
           val tpe = x.tpe[c.universe.type](c.universe)
           val staticallyElided = tpe.isEffectivelyFinal || tpe.isEffectivelyPrimitive
           if(x.isScala || !x.isPublic) {
@@ -61,7 +60,7 @@ private[pickling]  trait SourceGenerator extends Macro with FastTypeTagMacros {
         case y: IrMethod =>
           val tpe = y.returnType(c.universe)
           val staticallyElided = {
-            // TODO - Figure this out
+            // TODO - This is too naive of a determination.  In practice, we almost want an "always elide" and "never elide" mode.
             tpe.isEffectivelyFinal || tpe.isEffectivelyPrimitive
           }
           if (y.isPublic) putField(q"picklee.${newTermName(y.methodName)}", staticallyElided, tpe)
@@ -92,7 +91,6 @@ private[pickling]  trait SourceGenerator extends Macro with FastTypeTagMacros {
         CaseDef(Bind(otherTermName, Ident(nme.WILDCARD)), throwUnknownTag)
       }
       val runtimeDispatch = CaseDef(Ident(nme.WILDCARD), EmptyTree, createRuntimePickler(q"builder"))
-      // TODO - Figure out if we can handle runtime dispatch...
       val unknownDispatch =
         if(x.lookupRuntime) List(runtimeDispatch)
         else List(failDispatch)
@@ -178,7 +176,6 @@ private[pickling]  trait SourceGenerator extends Macro with FastTypeTagMacros {
   }
 
   def genUnpicklerLogic[T: c.WeakTypeTag](unpicklerAst: UnpicklerAst): c.Tree = {
-    // TODO - Make sure this lines up with existing unpickler logic
     val unpickleLogic = generateUnpickleImplFromAst(unpicklerAst)
     // Handle null + Ref types first
     unpickleNull(unpickleRef(unpickleLogic))
@@ -321,7 +318,6 @@ private[pickling]  trait SourceGenerator extends Macro with FastTypeTagMacros {
     q"_root_.scala.Predef.implicitly[_root_.scala.pickling.Unpickler[$tpe]]"
   def genSubclassUnpickler(x: SubclassUnpicklerDelegation): c.Tree = {
     val tpe = x.parent.tpe[c.universe.type](c.universe)
-    // TODO - Allow runtime pickler lookup if enabled...
     val defaultCase =
       if(x.lookupRuntime) CaseDef(Ident(nme.WILDCARD), EmptyTree, q"_root_.scala.pickling.internal.`package`.currentRuntime.picklers.genUnpickler(_root_.scala.pickling.internal.`package`.currentMirror, tagKey)")
       else CaseDef(Ident(nme.WILDCARD), EmptyTree, q"""throw new _root_.scala.pickling.PicklingException("Cannot unpickle, Unexpected tag: " + tagKey + " not recognized.")""")
@@ -366,10 +362,15 @@ private[pickling]  trait SourceGenerator extends Macro with FastTypeTagMacros {
       case x: UnpickleBehavior =>
         val behavior = x.operations.map(generateUnpickleImplFromAst).toList
         // TODO - This is kind of hacky.  We're trying to make sure during unpickling we always register/unregister appropriately...
+        //  This is actually guarranteed to fail if "structural sharing" is done in a way such that the shared "tree"
+        // of objects is needed to call the constructor. In this isntance, we are unable to register the new object
+        // before constructing it, leading to out of order OIDs and a failed deserialize.
+        // This is why we're deprecating sharing.
         x.operations match {
           case List() => q"null"
           case List(head: SubclassUnpicklerDelegation) => generateUnpickleImplFromAst(head)
             // TODO - Can we assume that ever additional operation is something which manipualtes the result?
+            // Once again, flakyness here is why we're deprecating sharing.
           case hd :: tail =>
             val hdTree = generateUnpickleImplFromAst(hd)
             val tlTree = tail.map(generateUnpickleImplFromAst)

--- a/core/src/main/scala/scala/pickling/generator/symbols.scala
+++ b/core/src/main/scala/scala/pickling/generator/symbols.scala
@@ -8,9 +8,7 @@ import scala.util.Try
 /**
  * A minimal symbol set to allow us to construct our mini-pickle-behavior language
  */
-private[pickling] sealed trait IrSymbol {
-  // TODO - isJava
-}
+private[pickling] sealed trait IrSymbol {}
 private[pickling] object IrSymbol {
   // TODO - This helper method should be available elsewhere.
   def allDeclaredMethodIncludingSubclasses(cls: IrClass): Seq[IrMethod] = {

--- a/core/src/main/scala/scala/pickling/generator/symbols.scala
+++ b/core/src/main/scala/scala/pickling/generator/symbols.scala
@@ -10,7 +10,6 @@ import scala.util.Try
  */
 private[pickling] sealed trait IrSymbol {}
 private[pickling] object IrSymbol {
-  // TODO - This helper method should be available elsewhere.
   def allDeclaredMethodIncludingSubclasses(cls: IrClass): Seq[IrMethod] = {
     def allmethods(clss: List[IrClass], mthds: Seq[IrMethod], visitedClasses: Set[String]): Seq[IrMethod] =
       clss match {
@@ -20,8 +19,6 @@ private[pickling] object IrSymbol {
           allmethods(tail ++ hd.parentClasses, newMthds ++ mthds, visitedClasses + hd.className)
         case Nil => mthds
       }
-    // TODO - We should maybe warn if we see transient fields that cause us not to compile correctly, or maybe
-    //       allow serializing transient fields...
     allmethods(List(cls), Nil, Set())
   }
 
@@ -34,8 +31,6 @@ private[pickling] object IrSymbol {
           allfields(tail ++ hd.parentClasses, newFields ++ fields, visitedClasses + hd.className)
         case Nil => fields
       }
-    // TODO - We should maybe warn if we see transient fields that cause us not to compile correctly, or maybe
-    //       allow serializing transient fields...
     allfields(List(cls), Nil, Set())
   }
 }
@@ -98,7 +93,7 @@ private[pickling] sealed trait IrMember extends IrSymbol {
   def javaReflectionName: String
   /** This is true if the field is marked transient (either by scala or java serialization). */
   def isMarkedTransient: Boolean
-  // TODO - Signatures
+  // TODO - Methods for returning signatures
 
 }
 private[pickling] trait IrField extends IrMember {

--- a/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
@@ -120,7 +120,6 @@ final class DefaultPicklerRegistry(generator: RuntimePicklerGenerator) extends P
     * @param p  The unpickler to register.
     */
   override def registerPicklerUnpickler[T](key: String, p: (Pickler[T] with Unpickler[T])): Unit = {
-    // TODO - Should we lock or something here?
     registerPickler(key, p)
     registerUnpickler(key, p)
   }
@@ -132,7 +131,6 @@ final class DefaultPicklerRegistry(generator: RuntimePicklerGenerator) extends P
     *                   this type.
     */
   override def registerPicklerUnpicklerGenerator[T](typeConstructorKey: String, generator: (AppliedType) => (Pickler[T] with Unpickler[T])): Unit = {
-    // TODO - Should we lock or something here?
     registerPicklerGenerator(typeConstructorKey, generator)
     registerUnpicklerGenerator(typeConstructorKey, generator)
   }

--- a/core/src/main/scala/scala/pickling/internal/HybridRuntime.scala
+++ b/core/src/main/scala/scala/pickling/internal/HybridRuntime.scala
@@ -1,0 +1,21 @@
+package scala.pickling.internal
+
+import java.util.concurrent.locks.ReentrantLock
+
+import scala.pickling.internal.DefaultPicklerRegistry
+import scala.pickling.refs.Share
+import scala.pickling.{Unpickler, Pickler, FastTypeTag, refs}
+import scala.pickling.spi.{RefRegistry, PicklerRegistry, PicklingRuntime}
+import scala.reflect.runtime
+
+/**
+ * This runtime will not use reflection to generate new picklers, but DOES allow lookup of statically generated
+ * picklers at runtime.
+ */
+class HybridRuntime extends PicklingRuntime {
+  override def currentMirror: runtime.universe.Mirror = runtime.currentMirror
+  override val picklers  = new DefaultPicklerRegistry(NoRuntimePicklerGeneration)
+  override val refRegistry: RefRegistry = new DefaultRefRegistry()
+  override val GRL: ReentrantLock = new ReentrantLock()
+  override def makeFastTag[T](tagKey: String): FastTypeTag[T] = FastTypeTag.apply(currentMirror, tagKey).asInstanceOf[FastTypeTag[T]]
+}

--- a/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
+++ b/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
@@ -9,13 +9,12 @@ import scala.pickling.spi.{PicklerRegistry, RefRegistry, PicklingRuntime}
 import scala.reflect.runtime
 
 /**
- * An implementation of the pickling runtime that tries to avoid ALL runtime picklers.
+ * An implementation of the pickling runtime that tries to avoid ALL runtime picklers,
+ * including runtime lookup of statically defined picklers.
  */
 final class NoReflectionRuntime() extends PicklingRuntime {
   /** The current reflection mirror to use when doing runtime unpickling/pickling. */
   override def currentMirror: runtime.universe.Mirror = runtime.currentMirror
-
-  // TODO - we should allow registered picklers, just no reflective pickler generation...
   object picklers extends PicklerRegistry {
     override def genUnpickler(mirror: runtime.universe.Mirror, tagKey: String)(implicit share: refs.Share): _root_.scala.pickling.Unpickler[_] =
       throw new UnsupportedOperationException(s"Runtime pickler generation is disabled.  Cannot create unpickler for $tagKey")

--- a/core/src/main/scala/scala/pickling/internal/package.scala
+++ b/core/src/main/scala/scala/pickling/internal/package.scala
@@ -16,9 +16,13 @@ package object internal {
   import compat._
 
   private[this] def initDefaultRuntime = {
-    // TODO - Figure out some way to configure the default runtime at startup.
-    if(true) new DefaultRuntime()
-    else new NoReflectionRuntime()
+    // TODO - Figure out a better way to configure this.... (typesafe config?)
+    sys.props.getOrElse("pickling.runtime", "default") match {
+      case "hybrid" => new HybridRuntime()
+      case "noreflection" => new NoReflectionRuntime()
+      case _ => new DefaultRuntime()
+
+    }
   }
   private[this] var currentRuntimeVar = new AtomicReference[spi.PicklingRuntime](initDefaultRuntime)
   def currentRuntime: spi.PicklingRuntime = currentRuntimeVar.get
@@ -107,13 +111,18 @@ package object internal {
 
 
   // ----- utilities for managing object identity -----
-  // TODO - deprecated all of these, or leave them for convenience?
+  @deprecated("Use `currentRuntime.refRegistry.pickle.registerPicklee` instead", "0.11")
   def lookupPicklee(picklee: Any): Int = currentRuntime.refRegistry.pickle.registerPicklee(picklee)
-  def registerPicklee(picklee: Any) = currentRuntime.refRegistry.pickle.registerPicklee(picklee)
+  @deprecated("Use `currentRuntime.refRegistry.pickle.registerPicklee` instead", "0.11")
+  def registerPicklee(picklee: Any): Int = currentRuntime.refRegistry.pickle.registerPicklee(picklee)
+  @deprecated("Use `currentRuntime.refRegistry.pickle.clear` instead", "0.11")
   def clearPicklees() = currentRuntime.refRegistry.pickle.clear()
+  @deprecated("Use `currentRuntime.refRegistry.unpickle.lookupUnpicklees` instead", "0.11")
   def lookupUnpicklee(index: Int): Any = currentRuntime.refRegistry.unpickle.lookupUnpicklee(index)
+  @deprecated("Use `currentRuntime.refRegistry.unpickle.preregisterUnpicklee` instead", "0.11")
   def preregisterUnpicklee() = currentRuntime.refRegistry.unpickle.preregisterUnpicklee()
+  @deprecated("Use `currentRuntime.refRegistry.unpickle.registerUnpicklee` instead", "0.11")
   def registerUnpicklee(unpicklee: Any, index: Int) = currentRuntime.refRegistry.unpickle.regsiterUnpicklee(index, unpicklee)
-
+  @deprecated("Use `currentRuntime.refRegistry.unpickle.clear` instead", "0.11")
   def clearUnpicklees() = currentRuntime.refRegistry.unpickle.clear()
 }

--- a/core/src/main/scala/scala/pickling/pickler/Date.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Date.scala
@@ -5,7 +5,6 @@ import java.util.{Date, TimeZone}
 import java.text.SimpleDateFormat
 
 trait DatePicklers extends PrimitivePicklers {
-  // TODO(jsuereth) - Register runtime pickler.
   implicit val datePickler: Pickler[Date] with Unpickler[Date] =
   new AbstractPicklerUnpickler[Date] {
     private val dateFormatTemplate = {
@@ -34,4 +33,5 @@ trait DatePicklers extends PrimitivePicklers {
       dateFormat.parse(result.asInstanceOf[String])
     }
   }
+  internal.currentRuntime.picklers.registerPicklerUnpickler(datePickler)
 }

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
@@ -25,7 +25,5 @@ trait JavaBigDecimalPicklers extends PrimitivePicklers {
       new BigDecimal(result.asInstanceOf[String])
     }
   }
-
-  // TODO - Figure out if we should somehow have these all registered somewhere else rather than take the hit at construction time.
-  internal.currentRuntime.picklers.registerPicklerUnpickler(javaBigDecimalPickler.tag.key, javaBigDecimalPickler)
+  internal.currentRuntime.picklers.registerPicklerUnpickler(javaBigDecimalPickler)
 }

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
@@ -27,7 +27,5 @@ trait JavaBigIntegerPicklers extends PrimitivePicklers {
       new BigInteger(result.asInstanceOf[String])
     }
   }
-
-  // TODO - Figure out if we should somehow have these all registered somewhere else rather than take the hit at construction time.
   internal.currentRuntime.picklers.registerPicklerUnpickler(javaBigIntegerPickler.tag.key, javaBigIntegerPickler)
 }

--- a/core/src/main/scala/scala/pickling/pickler/Primitives.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Primitives.scala
@@ -4,7 +4,6 @@ package pickler
 /** Picklers for primitive types.
  */
 trait PrimitivePicklers {
-  // TODO: figure out why removing these pickler/unpicklers slows down evactor1
   implicit val bytePickler: Pickler[Byte] with Unpickler[Byte] = PrimitivePickler[Byte]
   implicit val shortPickler: Pickler[Short] with Unpickler[Short] = PrimitivePickler[Short]
   implicit val charPickler: Pickler[Char] with Unpickler[Char] = PrimitivePickler[Char]

--- a/core/src/main/scala/scala/pickling/pickler/Ref.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Ref.scala
@@ -1,8 +1,9 @@
 package scala.pickling
 package pickler
 
-// TODO - We need to rethink structural sharing and references, fundamentally.
+@deprecated("Sharing is not guaranteed to be safe w/ all possible picklers.")
 trait RefPicklers {
+  @deprecated("Sharing is not guaranteed to be safe w/ all possible picklers.")
   implicit def refPickler: Pickler[refs.Ref] = throw new Error("cannot pickle refs")
   implicit val refUnpickler: Unpickler[refs.Ref] = PrimitivePickler[refs.Ref]
 }

--- a/core/src/main/scala/scala/pickling/pickler/Ref.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Ref.scala
@@ -1,7 +1,8 @@
 package scala.pickling
 package pickler
 
+// TODO - We need to rethink structural sharing and references, fundamentally.
 trait RefPicklers {
-  implicit def refPickler: Pickler[refs.Ref] = throw new Error("cannot pickle refs") // TODO: make this a macro
+  implicit def refPickler: Pickler[refs.Ref] = throw new Error("cannot pickle refs")
   implicit val refUnpickler: Unpickler[refs.Ref] = PrimitivePickler[refs.Ref]
 }

--- a/core/src/main/scala/scala/pickling/pickler/TypeTags.scala
+++ b/core/src/main/scala/scala/pickling/pickler/TypeTags.scala
@@ -31,7 +31,6 @@ trait TypeTagPicklers extends PrimitivePicklers {
       * @return Any an instance of the type we've unpickled.
       */
     override def unpickle(tag: String, reader: PReader): Any = {
-      // TODO - Check tag?
       val rk = reader.readField("key")
       rk.hintElidedType(stringPickler.tag)
       val key = stringPickler.unpickleEntry(rk).toString
@@ -39,9 +38,8 @@ trait TypeTagPicklers extends PrimitivePicklers {
     }
     override val tag: FastTypeTag[FastTypeTag[_]] = FastTypeTag.apply(internal.currentMirror, "scala.pickling.pickler.FastTypeTag").asInstanceOf[FastTypeTag[FastTypeTag[_]]]
 
-    // Ensure we register for runtime deserialization.
-    internal.currentRuntime.picklers.registerPickler(tag.key, this)
-    internal.currentRuntime.picklers.registerUnpickler(tag.key, this)
   }
+  // Ensure we register for runtime deserialization.
+  internal.currentRuntime.picklers.registerPicklerUnpickler(FastTypeTagPicklerUnpickler)
 }
 

--- a/core/src/main/scala/scala/pickling/refs/package.scala
+++ b/core/src/main/scala/scala/pickling/refs/package.scala
@@ -1,18 +1,22 @@
 package scala.pickling
 
 package object shareEverything {
+  @deprecated("Sharing is not guaranteed to be safe w/ all possible picklers.")
   implicit object ShareEverything extends refs.ShareEverything
 }
 
 package object shareNothing {
+  @deprecated("Sharing is not guaranteed to be safe w/ all possible picklers.")
   implicit object ShareNothing extends refs.ShareNothing
 }
 
 package refs {
+  @deprecated("Sharing is not guaranteed to be safe w/ all possible picklers.")
   final class Ref
 
   sealed trait Share
   object Share {
+    @deprecated("Sharing is not guaranteed to be safe w/ all possible picklers.")
     implicit object ShareNonPrimitives extends ShareNonPrimitives
   }
 

--- a/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
@@ -93,11 +93,6 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
     // debug(s"creating DefaultLogic for ${fir.name}")
     val staticClass = mirror.runtimeClass(fir.tpe.erasure)
     def pickleLogic(fldClass: Class[_], fldValue: Any, b: PBuilder, fldPickler: Pickler[Any], fldTag: FastTypeTag[_]): Unit = {
-      // TODO - Dynamic elides are no longer supported, but here is where they could be.  They were never generated
-      //        for non-runtime picklers, and therefore were of little use.
-      //        The issue with dynamic elides is that the unpickler needs to support them, and it's not
-      //        somethign you could know at runtime.
-      // if (fldValue == null || fldValue.getClass == staticClass) doSomeKindofDynamicElide, perhaps
       pickleInto(fldClass, fldValue, b, fldPickler, fldTag)
     }
   }

--- a/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
@@ -49,19 +49,22 @@ trait PicklerRegistry {
     *             In those situations, the pickler should be able to handle arbitrary (existential) type parameters.
     * @param p  The pickler to register.
     */
-  def registerPickler[T](key: String, p: Pickler[T]): Unit  // TODO - Return old pickler if one existed?
+  def registerPickler[T](key: String, p: Pickler[T]): Unit
+  def registerPickler[T](p: Pickler[T]): Unit = registerPickler(p.tag.key, p)
   /** Registers an unpickler with this registry for future use.
     * @param key  The type key for the unpickler. Note: In reflective scenarios this may not include type parameters.
     *             In those situations, the unpickler should be able to handle arbitrary (existential) type parameters.
     * @param p  The unpickler to register.
     */
   def registerUnpickler[T](key: String, p: Unpickler[T]): Unit
+  def registerUnpickler[T](p: Unpickler[T]): Unit = registerUnpickler(p.tag.key, p)
   /** Registers a pickler and unpickler for a type with this registry for future use.
     * @param key  The type key for the pickler. Note: In reflective scenarios this may not include type parameters.
     *             In those situations, the pickler should be able to handle arbitrary (existential) type parameters.
     * @param p  The unpickler to register.
     */
-  def registerPicklerUnpickler[T](key: String, p: (Pickler[T] with Unpickler[T])): Unit  // TODO - Return old pickler if one existed?
+  def registerPicklerUnpickler[T](key: String, p: (Pickler[T] with Unpickler[T])): Unit
+  def registerPicklerUnpickler[T](p: Pickler[T] with Unpickler[T]): Unit = registerPicklerUnpickler(p.tag.key, p)
 
 
   /** Registers a function which can generate picklers for a given type constructor.

--- a/core/src/test/scala/scala/pickling/generator/WillRobinsonGeneratorTest.scala
+++ b/core/src/test/scala/scala/pickling/generator/WillRobinsonGeneratorTest.scala
@@ -27,7 +27,6 @@ class WillRobinsonGeneratorTest extends FunSuite {
     assert(x != y)
     assert(x.toString == y.toString)
   }
-  // TODO - This is broken.
   test("private-this-val non-final class") {
     val x = new PrivateThisVal(5)
     implicit val p = PicklerUnpickler.generate[PrivateThisVal]

--- a/notes/0.11.0.markdown
+++ b/notes/0.11.0.markdown
@@ -1,0 +1,156 @@
+This is the second stable release of Scala Pickling, an automatic serialization framework made for Scala.
+It's fast, boilerplate-free, and allows users to easily swap in/out different serialization formats (such as binary, or JSON). 
+
+We will retain binary compatibility throughout the 0.11.x series. We'll also keep format compatibility during 0.11.x.
+
+## Pickling in a nutshell
+
+To pickle a value, let's say `Person("foo", 20)`, you need two things.
+A [pickler combinator][Kennedy] for the given type `Person`, and a pickle format.
+The `Pickler[A]` is responsible for breaking `A` down to abstract *entries*, *fields*, and *collections*.
+It's called a combinator, because complex pickler combinators can be composed from primitive picklers.
+The `PickleFormat` turns the abstract notions like *fields* into binary or text representation.
+
+## Defaults mode
+
+Here's a basic usage using `Defaults` mode.
+
+    scala> import scala.pickling.Defaults._, scala.pickling.json._
+    scala> case class Person(name: String, age: Int)
+    
+    scala> val pkl = Person("foo", 20).pickle
+    pkl: pickling.json.pickleFormat.PickleType =
+    JSONPickle({
+      "$type": "Person",
+      "name": "foo",
+      "age": 20
+    })
+
+    scala> val person = pkl.unpickle[Person]
+    person: Person = Person(foo,20)
+
+The `Defaults` mode automatically derives `Pickler[Person]` from the primitive picklers at compile-time!
+Because the code is statically generated, we can inline the string manipulations and make it fast.
+([Faster than Java serialization or Kryo][Miller], which also does not require schema)
+
+Note, because `Pickler[A]` is a typeclass, Pickling can be retrofitted to `Person`
+without modifying the class to inherit [Serializable][1] or something like that.
+
+## DIY protocol stack
+
+Starting from Pickling 0.10.0 offers picklers, ops, and formats as traits, which can be
+stacked together, so third-party libraries can provide custom modes.
+Suppose you only want to pickle primitive types and `Apple`, and don't want to automatically
+derive pickler combinators. Here's a custom mode:
+
+    scala> case class Apple(kind: String)
+    scala> val appleProtocol = {
+             import scala.pickling._
+             new pickler.PrimitivePicklers with pickler.RefPicklers
+                 with json.JsonFormats {
+               // Manually generate pickler for Apple
+               implicit val applePickler = PicklerUnpickler.generate[Apple]
+               // Don't fall back to runtime picklers
+               implicit val so = static.StaticOnly
+               // Provide custom functions
+               def toJsonString[A: Pickler](a: A): String =
+                 functions.pickle(a).value
+               def fromJsonString[A: Unpickler](s: String): A =
+                 functions.unpickle[A](json.JSONPickle(s))
+             }
+           }
+    scala> import appleProtocol._
+    
+    scala> toJsonString(Apple("honeycrisp"))
+    res0: String =
+    {
+      "$type": "Apple",
+      "kind": "honeycrisp"
+    }
+
+For more details see [Pickling][Pickling].
+
+
+## Enhanced static safety
+
+The 0.11.0 pickling release focuses on improving the stability and safety of staticly generated picklers, as well as
+warning the user when their types cannot be safely pickled using scala analysis available from scala macros, and will
+resort to runtime pickling.
+
+The new picklers support the following algorithms:
+
+| Algorithm | Statically Safe | Dsecription |
+|---|---|---|
+| Case class | X | uses static analysis to handle scala classes.  Safety requires case classes to be final. |
+| ADT  | X | uses static analysis to handle sealed traits/classes.  May require the use of `directKnownSubclasses`. |
+| Scala Singleton | X | uses static analysis to handle `object`s defined in scala. |
+| Externalizable |  | uses creative mechanism to fake Java's `Externalizable` interface for pickling. |
+| Will Robinson |   | Uses reflection and partial static analysis to generate pickling logic. |
+
+When in "static only" mode, only the statically safe algorithms for pickling are used.  You can enter "static only"
+mode via `import scala.pickling.static._` at the top of a file requring static safety.
+
+
+
+## Hand-written pickler/unpickler migration.
+
+0.11.0 also brings some changes to the internals of pickler generation.  Those who have hand-written pickelrs may
+need to alter the code (slightly) for this new verison.
+
+Here's a list of changes:
+
+- Removal of `hintStaticallyElidedType`, `hintDynamicallyElidedType` and `hintTag` for a single `hintElidedType` method.
+  This generally means picklers are less able to elide types, but consistently handle types during pickling and
+  unpickling phases.  Additionally, it improves the ability to handle a scenario where a pickler is statically 
+  generated, but the unpickler is dynamically generated later.
+- If picklers are sharing sub-structural content, they must still pickle fields/entries/collections after calling
+  `hintOid`.
+- `beginEntry` calls on `PBuilder` require a `FastTypeTag[_]`.
+- Structural sharing Method calls (`Ref`) from `scala.pickling.internal` have been moved to an interface:
+  `scala.pickling.internal.currentRuntime.refRegistrary` in the `pickler` and `unpickler` methods respectively.
+- Registering picklers for runtime serialization now uses a dedicated interface, and should be accessed via:
+  `scala.pickling.internal.currentRuntime.pickler`.  See the `PicklerRegistry` trait for details.
+
+
+## Pickle format migration
+
+Here's a list of changes:
+
+- Pickle formats no longer HAVE to support the `Ref` mechanism of structural sharing.
+- The `hintElidedType` changes have caused picklers to be less able to elide types.  While not formally specified,
+  if a format does not find a type, but does have an "entry", it is acceptable to return an empty string.  Picklers
+  which allow elided types will ignore the type string anyway.
+
+## Custom runtime behavior
+
+Starting in 0.11.0, pickling now allows users to customize the runtime behavior.  When creating a pickling
+protocol stack, it is possible to inject a new runtime implementation before initializing any of the default picklers.
+Here's an example alternative implementation:
+
+```
+package my.protocol
+
+import scala.pickling._
+
+
+object Defaults extends {
+  // Minor hack to make sure runtime is initialized before all the "autoregistered" primtiive picklers
+  val ignoreMe =
+    internal.replaceRuntime(new internal.NoReflectionRuntime)
+} with Ops with pickler.AllPicklers
+```
+
+Additionally, the default runtime can be controlled via the environment variable `pickling.runtime`.
+
+| Value | Beahvior |
+|---|---|
+| hybrid | uses `scala.pickling.internal.HybridRuntime` |
+| norefleciton | uses `scala.pickling.internal.NoReflectionRuntime` |
+| <empty> | uses `scala.pickling.internal.DefaultRuntime` |
+
+Additionally, the `scala.pickling.spi` package defines the set of APIs for creating your own runtime behavior.
+
+  [Kennedy]: http://research.microsoft.com/pubs/64036/picklercombinators.pdf
+  [Miller]: http://infoscience.epfl.ch/record/187787/files/oopsla-pickling_1.pdf
+  [Pickling]: https://github.com/scala/pickling
+  [1]: http://docs.oracle.com/javase/7/docs/api/java/io/Serializable.html


### PR DESCRIPTION
- Remove TODOs which were already handled
- Fixed 2.10.x build (although probably not hugely necessary at this point)
- Better documentation of Hintable
- Creation of a hybrid runtime that has runtime lookup of statically generated picklers (but not reflection-generated picklers).
- Deprecated 'share' notions in pickling, as these have some "fun" corner case explosions.

Possibly review by @eed3si9n, @phaller or @heathermiller
