### PR TITLE
Fix the build (and update for 0.11.0 release)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Benchmark._ // see project/Benchmark.scala
 import Dependencies._ // see project/Dependencies.scala
 
-val buildVersion = "0.10.2-SNAPSHOT"
+val buildVersion = "0.11.0-M1"
 
 def commonSettings = Seq(
   version in ThisBuild := buildVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import Benchmark._ // see project/Benchmark.scala
 import Dependencies._ // see project/Dependencies.scala
+import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
+import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 val buildVersion = "0.11.0-M1"
 
@@ -38,7 +40,16 @@ def commonSettings = Seq(
   },
   pomIncludeRepository := { x => false },
   pomExtra := <inceptionYear>2013</inceptionYear>,
-  credentials ++= Util.loadCredentials()
+  credentials ++= Util.loadCredentials(),
+  pomPostProcess := { (node: XmlNode) =>
+    new RuleTransformer(new RewriteRule {
+      override def transform(node: XmlNode): XmlNodeSeq = node match {
+        case e: Elem if e.label == "dependency" && e.child.exists(child => child.label == "artifactId" && child.text.contains("testutil")) =>
+          Comment(s"Ommitted test-util dependency")
+        case _ => node
+      }
+    }).transform(node).head
+  }
 )
 def noPublish = Seq(
   publish := {},

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._ // see project/Dependencies.scala
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-val buildVersion = "0.11.0-M1"
+val buildVersion = "0.11.0-SNAPSHOT"
 
 def commonSettings = Seq(
   version in ThisBuild := buildVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9


### PR DESCRIPTION
Now we can really cut releases.
-  Remove testutil from dependency list (it is not published)
- Bump sbt version.
- Bump build version

Review by @eed3si9n
