### PR TITLE
Add automatic registering of picklers/unpicklers

### DIFF
--- a/core/src/main/scala/scala/pickling/generator/sourcegen.scala
+++ b/core/src/main/scala/scala/pickling/generator/sourcegen.scala
@@ -1,12 +1,8 @@
 package scala.pickling
 package generator
 
-import scala.reflect.api.Universe
-
-/** This is the portion of code which can actually generate a pickler/unpickler object instance
-  * from the IR AST.
-  *
-  *
+/** This is the portion of code which can actually generate a pickler/unpickler
+  * object instance from the IR AST.
   */
 private[pickling]  trait SourceGenerator extends Macro with tags.FastTypeTagMacros {
   import c.universe._
@@ -400,6 +396,11 @@ private[pickling]  trait SourceGenerator extends Macro with tags.FastTypeTagMacr
         implicit object $picklerName extends _root_.scala.pickling.Pickler[$tpe] with _root_.scala.pickling.Generated {
           def pickle(picklee: $tpe, builder: _root_.scala.pickling.PBuilder): _root_.scala.Unit = ${genPicklerLogic[T](picklerAst)}
           val tag: _root_.scala.pickling.FastTypeTag[$tpe] = $createTagTree
+
+          if(_root_.scala.pickling.internal.currentRuntime.picklers.lookupPickler(tag.key).isEmpty) {
+            _root_.scala.pickling.internal.currentRuntime.picklers.registerPickler(this)
+          }
+
         }
         $picklerName
       }
@@ -416,6 +417,11 @@ private[pickling]  trait SourceGenerator extends Macro with tags.FastTypeTagMacr
           implicit object $unpicklerName extends  _root_.scala.pickling.Unpickler[$tpe] with _root_.scala.pickling.Generated {
             def unpickle(tagKey: _root_.java.lang.String, reader: _root_.scala.pickling.PReader): _root_.scala.Any = $unpickleLogic
             val tag: _root_.scala.pickling.FastTypeTag[$tpe] = $createTagTree
+
+            if(_root_.scala.pickling.internal.currentRuntime.picklers.lookupUnpickler(tag.key).isEmpty) {
+              _root_.scala.pickling.internal.currentRuntime.picklers.registerUnpickler(this)
+            }
+
           }
           $unpicklerName : _root_.scala.pickling.Unpickler[$tpe] with _root_.scala.pickling.Generated
        }
@@ -435,6 +441,15 @@ private[pickling]  trait SourceGenerator extends Macro with tags.FastTypeTagMacr
             override def pickle(picklee: $tpe, builder: _root_.scala.pickling.PBuilder): _root_.scala.Unit = $pickleLogic
             override def unpickle(tagKey: _root_.java.lang.String, reader: _root_.scala.pickling.PReader): _root_.scala.Any = $unpickleLogic
             override val tag: _root_.scala.pickling.FastTypeTag[$tpe] = $createTagTree
+
+            if(_root_.scala.pickling.internal.currentRuntime.picklers.lookupPickler(tag.key).isEmpty) {
+              _root_.scala.pickling.internal.currentRuntime.picklers.registerPickler(this)
+            }
+
+            if(_root_.scala.pickling.internal.currentRuntime.picklers.lookupUnpickler(tag.key).isEmpty) {
+              _root_.scala.pickling.internal.currentRuntime.picklers.registerUnpickler(this)
+            }
+
           }
           $name : _root_.scala.pickling.AbstractPicklerUnpickler[$tpe] with _root_.scala.pickling.Generated
        }

--- a/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
@@ -52,7 +52,15 @@ final class DefaultPicklerRegistry(generator: RuntimePicklerGenerator) extends P
   override def registerUnpickler[T](key: String, p: Unpickler[T]): Unit =
     unpicklerMap.put(key, p)
 
-  /** Checks the existince of an unpickler. */
+  /** Checks the existence of a pickler ignoring the registered generators. */
+  override def lookupExistingPickler(key: String): Option[Pickler[_]] =
+    picklerMap.get(key)
+
+  /** Checks the existence of an unpickler ignoring the registered generators. */
+  override def lookupExistingUnpickler(key: String): Option[Unpickler[_]] =
+    unpicklerMap.get(key)
+
+  /** Checks the existence of an unpickler. */
   override def lookupUnpickler(key: String): Option[Unpickler[_]] = {
     unpicklerMap.get(key) match {
       case x: Some[Unpickler[_]] => x

--- a/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
+++ b/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
@@ -22,6 +22,8 @@ final class NoReflectionRuntime() extends PicklingRuntime {
       throw new UnsupportedOperationException(s"Runtime pickler generation is disabled.  Cannot create pickler for $tag")
     override def lookupUnpickler(key: String): Option[Unpickler[_]] = None
     override def lookupPickler(key: String): Option[Pickler[_]] = None
+    override def lookupExistingPickler(key: String): Option[Pickler[_]] = None
+    override def lookupExistingUnpickler(key: String): Option[Unpickler[_]] = None
     override def registerPickler[T](key: String, p: Pickler[T]): Unit = ()
     override def registerUnpicklerGenerator[T](typeConstructorKey: String, generator: (FastTypeTag[_]) => Unpickler[T]): Unit = ()
     override def registerPicklerUnpicklerGenerator[T](typeConstructorKey: String, generator: (FastTypeTag[_]) => Pickler[T] with Unpickler[T]): Unit = ()

--- a/core/src/main/scala/scala/pickling/pickler/Any.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Any.scala
@@ -2,7 +2,8 @@ package scala.pickling
 package pickler
 
 /** An pickler for "Any" value (will look up pickler at runtime, or generate it. */
-object AnyPickler extends Pickler[Any] {
+object AnyPickler extends Pickler[Any] with AutoRegisterPickler[Any] {
+  override def tag: FastTypeTag[Any] = FastTypeTag.Any
   override def pickle(picklee: Any, builder: PBuilder): Unit = {
     // Here we just look up the pickler.
     val clazz = picklee.getClass
@@ -13,16 +14,15 @@ object AnyPickler extends Pickler[Any] {
     val p = internal.currentRuntime.picklers.genPickler(classLoader, clazz, tag)
     p.asInstanceOf[Pickler[Any]].pickle(picklee, builder)
   }
-  override def tag: FastTypeTag[Any] = FastTypeTag.Any
   override def toString = "AnyPickler"
 }
 /** An unpickler for "Any" value (will look up unpickler at runtime, or generate it. */
-object AnyUnpickler extends Unpickler[Any] {
+object AnyUnpickler extends Unpickler[Any] with AutoRegisterUnpickler[Any] {
+  def tag: FastTypeTag[Any] = FastTypeTag.Any
   def unpickle(tag: String, reader: PReader): Any = {
     val actualUnpickler = internal.currentRuntime.picklers.genUnpickler(scala.reflect.runtime.currentMirror, tag)
     actualUnpickler.unpickle(tag, reader)
   }
-  def tag: FastTypeTag[Any] = FastTypeTag.Any
   override def toString = "AnyUnPickler"
 }
 

--- a/core/src/main/scala/scala/pickling/pickler/Date.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Date.scala
@@ -6,7 +6,7 @@ import java.text.SimpleDateFormat
 
 trait DatePicklers extends PrimitivePicklers {
   implicit val datePickler: Pickler[Date] with Unpickler[Date] =
-  new AbstractPicklerUnpickler[Date] {
+  new AbstractPicklerUnpickler[Date] with AutoRegister[Date] {
     private val dateFormatTemplate = {
       val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") //use ISO_8601 format
       format.setLenient(false)
@@ -15,7 +15,7 @@ trait DatePicklers extends PrimitivePicklers {
     }
     private def dateFormat = dateFormatTemplate.clone.asInstanceOf[SimpleDateFormat]
 
-    val tag = FastTypeTag[Date]("java.util.Date")
+    lazy val tag = FastTypeTag[Date]("java.util.Date")
     def pickle(picklee: Date, builder: PBuilder): Unit = {
       builder.beginEntry(picklee, tag)
 

--- a/core/src/main/scala/scala/pickling/pickler/Either.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Either.scala
@@ -6,7 +6,7 @@ trait EitherPicklers {
   // TODO(jsuereth) - Register pickler generators
 
   implicit def pickleLeft[L, R](implicit lp: Pickler[L], t: FastTypeTag[Left[L,R]]): Pickler[Left[L, R]] =
-     new AbstractPickler[Left[L, R]] {
+     new AbstractPickler[Left[L, R]] with AutoRegisterPickler[Left[L, R]] {
        override def pickle(picklee: Left[L, R], builder: PBuilder): Unit = {
          builder.beginEntry(picklee, tag)
          if(lp.tag.isEffectivelyPrimitive) builder.hintElidedType(lp.tag)
@@ -17,7 +17,7 @@ trait EitherPicklers {
        override def toString = s"LeftPickler($tag)"
      }
   implicit def pickleRight[L,R](implicit rp: Pickler[R], t: FastTypeTag[Right[L,R]]): Pickler[Right[L,R]] =
-    new AbstractPickler[Right[L, R]] {
+    new AbstractPickler[Right[L, R]] with AutoRegisterPickler[Right[L, R]] {
       override def pickle(picklee: Right[L, R], builder: PBuilder): Unit = {
         builder.beginEntry(picklee, tag)
         if(rp.tag.isEffectivelyPrimitive) builder.hintElidedType(rp.tag)
@@ -29,7 +29,7 @@ trait EitherPicklers {
     }
 
   implicit def pickleEither[L,R](implicit rp: Pickler[Right[L,R]], lp: Pickler[Left[L,R]], t: FastTypeTag[Either[L,R]]): Pickler[Either[L,R]] =
-    new AbstractPickler[Either[L, R]] {
+    new AbstractPickler[Either[L, R]] with AutoRegisterPickler[Either[L, R]] {
       override def pickle(picklee: Either[L, R], builder: PBuilder): Unit = {
         picklee match {
           case l: Left[L,R] => lp.pickle(l, builder)
@@ -41,7 +41,7 @@ trait EitherPicklers {
     }
 
   implicit def unpickleLeft[L, R](implicit lp: Unpickler[L], t: FastTypeTag[Left[L,R]]): Unpickler[Left[L, R]] =
-    new AbstractUnpickler[Left[L, R]] {
+    new AbstractUnpickler[Left[L, R]] with AutoRegisterUnpickler[Left[L, R]] {
       override def toString = s"LeftUnpickler($tag)"
       override def unpickle(tag: String, reader: PReader): Any = {
         // TODO - check tag == our tag?
@@ -52,7 +52,7 @@ trait EitherPicklers {
       override def tag: FastTypeTag[Left[L, R]] = t
     }
   implicit def unpickleRight[L, R](implicit rp: Unpickler[R], t: FastTypeTag[Right[L,R]]): Unpickler[Right[L, R]] =
-    new AbstractUnpickler[Right[L, R]] {
+    new AbstractUnpickler[Right[L, R]] with AutoRegisterUnpickler[Right[L, R]] {
       override def unpickle(tag: String, reader: PReader): Any = {
         // TODO - check tag == our tag?
         val rr = reader.readField("b")
@@ -64,7 +64,7 @@ trait EitherPicklers {
     }
   implicit def unpickleEither[L, R](implicit rp: Unpickler[Right[L,R]], lp: Unpickler[Left[L,R]],
                                    t: FastTypeTag[Either[L,R]]): Unpickler[Either[L, R]] =
-    new AbstractUnpickler[Either[L, R]] {
+    new AbstractUnpickler[Either[L, R]] with AutoRegisterUnpickler[Either[L, R]] {
       override def unpickle(tag: String, reader: PReader): Any = {
         if(tag == rp.tag.key) rp.unpickle(tag,reader)
           else if(tag == lp.tag.key) lp.unpickle(tag, reader)

--- a/core/src/main/scala/scala/pickling/pickler/Iterable.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Iterable.scala
@@ -68,7 +68,7 @@ object TravPickler {
   def apply[T, C <% Traversable[_]]
     (implicit elemPickler: Pickler[T], elemUnpickler: Unpickler[T],
               cbf: CanBuildFrom[C, T, C], collTag: FastTypeTag[C]): AbstractPicklerUnpickler[C] =
-    new AbstractPicklerUnpickler[C] {
+    new AbstractPicklerUnpickler[C] with AutoRegister[C] {
 
     val elemTag  = elemPickler.tag
     val isPrimitive = elemTag.isEffectivelyPrimitive

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigDecimal.scala
@@ -7,23 +7,23 @@ import java.math.BigDecimal
   * Note; This currently serialzies as a string.
   */
 trait JavaBigDecimalPicklers extends PrimitivePicklers {
-  implicit val javaBigDecimalPickler:
-    Pickler[BigDecimal] with Unpickler[BigDecimal] = new AbstractPicklerUnpickler[BigDecimal] {
-    val tag = FastTypeTag[BigDecimal]("java.math.BigDecimal")
-    def pickle(picklee: BigDecimal, builder: PBuilder): Unit = {
-      builder.beginEntry(picklee, tag)
-      builder.putField("value", b => {
-        b.hintElidedType(implicitly[FastTypeTag[String]])
-        stringPickler.pickle(picklee.toString, b)
-      })
-      builder.endEntry()
+  implicit val javaBigDecimalPickler: Pickler[BigDecimal] with Unpickler[BigDecimal] =
+    new AbstractPicklerUnpickler[BigDecimal] with AutoRegister[BigDecimal] {
+      lazy val tag = FastTypeTag[BigDecimal]("java.math.BigDecimal")
+      def pickle(picklee: BigDecimal, builder: PBuilder): Unit = {
+        builder.beginEntry(picklee, tag)
+        builder.putField("value", b => {
+          b.hintElidedType(implicitly[FastTypeTag[String]])
+          stringPickler.pickle(picklee.toString, b)
+        })
+        builder.endEntry()
+      }
+      def unpickle(tag: String, reader: PReader): Any = {
+        val reader1 = reader.readField("value")
+        reader1.hintElidedType(implicitly[FastTypeTag[String]])
+        val result = stringPickler.unpickleEntry(reader1)
+        new BigDecimal(result.asInstanceOf[String])
+      }
     }
-    def unpickle(tag: String, reader: PReader): Any = {
-      val reader1 = reader.readField("value")
-      reader1.hintElidedType(implicitly[FastTypeTag[String]])
-      val result = stringPickler.unpickleEntry(reader1)
-      new BigDecimal(result.asInstanceOf[String])
-    }
-  }
   internal.currentRuntime.picklers.registerPicklerUnpickler(javaBigDecimalPickler)
 }

--- a/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaBigInteger.scala
@@ -6,25 +6,25 @@ import java.math.BigInteger
 
 /** This contains implicits which can serialize java.math.BigInteger values. */
 trait JavaBigIntegerPicklers extends PrimitivePicklers {
-  implicit val javaBigIntegerPickler:
-    Pickler[BigInteger] with Unpickler[BigInteger] = new AbstractPicklerUnpickler[BigInteger] {
-    val tag = FastTypeTag[BigInteger]("java.math.BigInteger")
-    def pickle(picklee: BigInteger, builder: PBuilder): Unit = {
-      builder.beginEntry(picklee, tag)
+  implicit val javaBigIntegerPickler: Pickler[BigInteger] with Unpickler[BigInteger] =
+    new AbstractPicklerUnpickler[BigInteger] with AutoRegister[BigInteger] {
+      lazy val tag = FastTypeTag[BigInteger]("java.math.BigInteger")
+      def pickle(picklee: BigInteger, builder: PBuilder): Unit = {
+        builder.beginEntry(picklee, tag)
 
-      builder.putField("value", b => {
-        b.hintElidedType(FastTypeTag.String)
-        stringPickler.pickle(picklee.toString, b)
-      })
+        builder.putField("value", b => {
+          b.hintElidedType(FastTypeTag.String)
+          stringPickler.pickle(picklee.toString, b)
+        })
 
-      builder.endEntry()
+        builder.endEntry()
+      }
+      def unpickle(tag: String, reader: PReader): Any = {
+        val reader1 = reader.readField("value")
+        reader1.hintElidedType(FastTypeTag.String)
+        val result = stringPickler.unpickleEntry(reader1)
+        new BigInteger(result.asInstanceOf[String])
+      }
     }
-    def unpickle(tag: String, reader: PReader): Any = {
-      val reader1 = reader.readField("value")
-      reader1.hintElidedType(FastTypeTag.String)
-      val result = stringPickler.unpickleEntry(reader1)
-      new BigInteger(result.asInstanceOf[String])
-    }
-  }
   internal.currentRuntime.picklers.registerPicklerUnpickler(javaBigIntegerPickler)
 }

--- a/core/src/main/scala/scala/pickling/pickler/JavaUUIDPickler.scala
+++ b/core/src/main/scala/scala/pickling/pickler/JavaUUIDPickler.scala
@@ -5,37 +5,37 @@ import java.util.UUID
 
 trait JavaUUIDPicklers extends PrimitivePicklers {
 
-  implicit val javaUUIDPickler:
-    Pickler[UUID] with Unpickler[UUID] = new AbstractPicklerUnpickler[UUID] {
-    val tag = FastTypeTag[UUID]("java.util.UUID")
-    def pickle(picklee: java.util.UUID, builder: PBuilder):Unit = {
-      builder.beginEntry(picklee, tag)
+  implicit val javaUUIDPickler: Pickler[UUID] with Unpickler[UUID] =
+    new AbstractPicklerUnpickler[UUID] with AutoRegister[UUID] {
+      lazy val tag = FastTypeTag[UUID]("java.util.UUID")
+      def pickle(picklee: java.util.UUID, builder: PBuilder):Unit = {
+        builder.beginEntry(picklee, tag)
 
-      builder.putField("msb", { b =>
-        b.hintElidedType(FastTypeTag.Long)
-        longPickler.pickle(picklee.getMostSignificantBits, b)
-      })
-      builder.putField("lsb", { b =>
-        b.hintElidedType(FastTypeTag.Long)
-        longPickler.pickle(picklee.getLeastSignificantBits, b)
-      })
-      builder.endEntry()
-    }
+        builder.putField("msb", { b =>
+          b.hintElidedType(FastTypeTag.Long)
+          longPickler.pickle(picklee.getMostSignificantBits, b)
+        })
+        builder.putField("lsb", { b =>
+          b.hintElidedType(FastTypeTag.Long)
+          longPickler.pickle(picklee.getLeastSignificantBits, b)
+        })
+        builder.endEntry()
+      }
 
-    def unpickle(tag: String, reader: PReader): Any = {
-      reader.hintElidedType(FastTypeTag.Long)
-      reader.pinHints()
-      val r1 = reader.readField("msb")
-      val tag1 = r1.beginEntry()
-      val msb = longPickler.unpickle(tag1, r1).asInstanceOf[Long]
-      r1.endEntry()
-      val r2 = reader.readField("lsb")
-      val tag2 = r2.beginEntry()
-      val lsb = longPickler.unpickle(tag2, r2).asInstanceOf[Long]
-      r2.endEntry()
-      reader.unpinHints()
-      new java.util.UUID(msb, lsb)
+      def unpickle(tag: String, reader: PReader): Any = {
+        reader.hintElidedType(FastTypeTag.Long)
+        reader.pinHints()
+        val r1 = reader.readField("msb")
+        val tag1 = r1.beginEntry()
+        val msb = longPickler.unpickle(tag1, r1).asInstanceOf[Long]
+        r1.endEntry()
+        val r2 = reader.readField("lsb")
+        val tag2 = r2.beginEntry()
+        val lsb = longPickler.unpickle(tag2, r2).asInstanceOf[Long]
+        r2.endEntry()
+        reader.unpinHints()
+        new java.util.UUID(msb, lsb)
+      }
     }
-  }
   internal.currentRuntime.picklers.registerPicklerUnpickler(javaUUIDPickler)
 }

--- a/core/src/main/scala/scala/pickling/pickler/Primitives.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Primitives.scala
@@ -17,12 +17,15 @@ trait PrimitivePicklers {
   implicit val unitPickler: Pickler[Unit] with Unpickler[Unit] = PrimitivePickler[Unit]
 }
 
-class PrimitivePickler[T: FastTypeTag](name: String) extends AutoRegister[T](name) {
-  def pickle(picklee: T, builder: PBuilder): Unit = {
+class PrimitivePickler[T: FastTypeTag](name: String)
+  extends AbstractPicklerUnpickler[T] with AutoRegister[T] {
+
+  override def tag = implicitly[FastTypeTag[T]]
+  override def pickle(picklee: T, builder: PBuilder): Unit = {
     builder.beginEntry(picklee, tag)
     builder.endEntry()
   }
-  def unpickle(tag: String, reader: PReader): Any = {
+  override def unpickle(tag: String, reader: PReader): Any = {
     try {
       // TODO - beginEntry/endEntry?
       reader.readPrimitive()

--- a/core/src/main/scala/scala/pickling/pickler/TypeTags.scala
+++ b/core/src/main/scala/scala/pickling/pickler/TypeTags.scala
@@ -9,7 +9,8 @@ trait TypeTagPicklers extends PrimitivePicklers {
     FastTypeTagPicklerUnpickler.asInstanceOf[AbstractPicklerUnpickler[FastTypeTag[T]]]
 
 
-  private[pickler] object FastTypeTagPicklerUnpickler extends AbstractPicklerUnpickler[FastTypeTag[_]] {
+  private[pickler] object FastTypeTagPicklerUnpickler
+    extends AbstractPicklerUnpickler[FastTypeTag[_]] with AutoRegister[FastTypeTag[_]] {
     override def pickle(picklee: FastTypeTag[_], builder: PBuilder): Unit = {
       builder.beginEntry(picklee, tag)
       builder.putField("key", { b =>
@@ -36,7 +37,7 @@ trait TypeTagPicklers extends PrimitivePicklers {
       val key = stringPickler.unpickleEntry(rk).toString
       FastTypeTag.apply(key)
     }
-    override val tag: FastTypeTag[FastTypeTag[_]] = FastTypeTag.apply("scala.pickling.pickler.FastTypeTag").asInstanceOf[FastTypeTag[FastTypeTag[_]]]
+    override lazy val tag: FastTypeTag[FastTypeTag[_]] = FastTypeTag.apply("scala.pickling.pickler.FastTypeTag").asInstanceOf[FastTypeTag[FastTypeTag[_]]]
 
   }
   // Ensure we register for runtime deserialization.

--- a/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
@@ -41,6 +41,11 @@ trait PicklerRegistry {
     */
   def lookupPickler(key: String): Option[Pickler[_]]
 
+  /** Checks the existence of an unpickler ignoring the registered generators. */
+  def lookupExistingUnpickler(key: String): Option[Unpickler[_]]
+
+  /** Checks the existence of a pickler ignoring the registered generators. */
+  def lookupExistingPickler(key: String): Option[Pickler[_]]
 
   /** Registers a pickler with this registry for future use.
     *

--- a/core/src/test/scala/pickling/run/autoregistering-picklers-unpicklers.scala
+++ b/core/src/test/scala/pickling/run/autoregistering-picklers-unpicklers.scala
@@ -5,24 +5,25 @@ import scala.pickling._
 import Defaults._
 import json._
 
-class AutoRegistrationTest extends FunSuite {
+class AutoRegisteringTest extends FunSuite {
 
   case class Foo[T](value: T)
+  import scala.pickling.internal.currentRuntime
 
   test("picklers should autoregister themselves when they are instantiated") {
 
-    val pickler = implicitly[Pickler[Foo[List[String]]]]
+    val pickler = implicitly[Pickler[Foo[List[(Int, String)]]]]
     val key = pickler.tag.key
-    val x = scala.pickling.internal.currentRuntime.picklers.lookupPickler(key)
+    val x = currentRuntime.picklers.lookupPickler(key)
     assert(x.get === pickler)
 
   }
 
   test("unpicklers should autoregister themselves when they are instantiated") {
 
-    val unpickler = implicitly[Unpickler[Foo[List[String]]]]
+    val unpickler = implicitly[Unpickler[Foo[List[(Int, String)]]]]
     val key = unpickler.tag.key
-    val y = scala.pickling.internal.currentRuntime.picklers.lookupUnpickler(key)
+    val y = currentRuntime.picklers.lookupUnpickler(key)
     assert(y.get === unpickler)
 
   }

--- a/core/src/test/scala/pickling/run/autoregistration.scala
+++ b/core/src/test/scala/pickling/run/autoregistration.scala
@@ -1,0 +1,31 @@
+package scala.pickling.runtime
+
+import org.scalatest.FunSuite
+import scala.pickling._
+import Defaults._
+import json._
+
+class AutoRegistrationTest extends FunSuite {
+
+  case class Foo[T](value: T)
+
+  test("picklers should autoregister themselves when they are instantiated") {
+
+    val pickler = implicitly[Pickler[Foo[List[String]]]]
+    val key = pickler.tag.key
+    val x = scala.pickling.internal.currentRuntime.picklers.lookupPickler(key)
+    assert(x.get === pickler)
+
+  }
+
+  test("unpicklers should autoregister themselves when they are instantiated") {
+
+    val unpickler = implicitly[Unpickler[Foo[List[String]]]]
+    val key = unpickler.tag.key
+    val y = scala.pickling.internal.currentRuntime.picklers.lookupUnpickler(key)
+    assert(y.get === unpickler)
+
+  }
+
+}
+

--- a/core/src/test/scala/pickling/run/non-public-weird.scala
+++ b/core/src/test/scala/pickling/run/non-public-weird.scala
@@ -29,19 +29,17 @@ class NonPublicWeirdTest extends FunSuite {
     """.stripMargin.trim)
     assert(personPickle.unpickle[Person].toString === person.toString)
 
-    // TODO: when generating a Person pickler at runtime, we should be able to reuse the one which was generated at compile-time
-    // but we aren't auto-registering the compiled picklers.
-    // Once we do so these JSON pickles should change.
+    // This will get the registered pickler for person
     val anyPickle = (person: Any).pickle
     assert(anyPickle.toString === """
       |JSONPickle({
       |  "$type": "scala.pickling.non.public.weird.Person",
-      |  "name": "Eugene",
       |  "hobby": {
+      |    "attitude": "loving it",
       |    "name": "hacking",
-      |    "notes": "mostly Scala",
-      |    "attitude": "loving it"
-      |  }
+      |    "notes": "mostly Scala"
+      |  },
+      |  "name": "Eugene"
       |})
     """.stripMargin.trim)
     assert(anyPickle.unpickle[Person].toString === person.toString)


### PR DESCRIPTION
- This, contrary to what I discussed with Josh, performs the
  registration of picklers and unpicklers only when they are initialised.
- Note that this only registers picklers/unpicklers if they are actually
  instantiated (the registration code will end up in the constructor).
- We double check that there's no pickler/unpickler mapped to a key to
  register it in the map, even if we have the guarantee that only one will be
  created for a given type `T`. Therefore, the first generated for a given type
  will be the one that will stay always in the map.
