### PR TITLE
Add lazy initialization and isLookupEnabled

### DIFF
--- a/core/src/main/scala/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/scala/pickling/Pickler.scala
@@ -102,27 +102,11 @@ object PicklerUnpickler {
   }
 }
 
-object AutoRegister {
-  import scala.pickling.internal.currentRuntime
-
-  private def isLookupEnabled: Boolean =
-    currentRuntime.picklers.isLookupEnabled
-
-  private[pickling] def existsPicklerFor(key: String) =
-    isLookupEnabled && currentRuntime.picklers.lookupExistingPickler(key).isEmpty
-
-  private[pickling] def existsUnpicklerFor(key: String) =
-    isLookupEnabled && currentRuntime.picklers.lookupExistingUnpickler(key).isEmpty
-
-}
-
 trait AutoRegisterPickler[T] {
   this: Pickler[T] =>
 
   locally {
-    if (AutoRegister.existsPicklerFor(tag.key)) {
-      currentRuntime.picklers.registerPickler(this)
-    }
+    currentRuntime.picklers.registerPickler(this)
   }
 
 }
@@ -131,9 +115,7 @@ trait AutoRegisterUnpickler[T] {
   this: Unpickler[T] =>
 
   locally {
-    if (AutoRegister.existsUnpicklerFor(tag.key)) {
-      currentRuntime.picklers.registerUnpickler(this)
-    }
+    currentRuntime.picklers.registerUnpickler(this)
   }
 
 }

--- a/core/src/main/scala/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/scala/pickling/Pickler.scala
@@ -106,7 +106,7 @@ object AutoRegister {
   import scala.pickling.internal.currentRuntime
 
   private def isLookupEnabled: Boolean =
-    !currentRuntime.isInstanceOf[NoReflectionRuntime]
+    currentRuntime.picklers.isLookupEnabled
 
   private[pickling] def existsPicklerFor(key: String) =
     isLookupEnabled && currentRuntime.picklers.lookupExistingPickler(key).isEmpty

--- a/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
@@ -52,6 +52,8 @@ final class DefaultPicklerRegistry(generator: RuntimePicklerGenerator) extends P
   override def registerUnpickler[T](key: String, p: Unpickler[T]): Unit =
     unpicklerMap.put(key, p)
 
+  override val isLookupEnabled = true
+
   /** Checks the existence of a pickler ignoring the registered generators. */
   override def lookupExistingPickler(key: String): Option[Pickler[_]] =
     picklerMap.get(key)

--- a/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/internal/DefaultPicklerRegistry.scala
@@ -52,6 +52,12 @@ final class DefaultPicklerRegistry(generator: RuntimePicklerGenerator) extends P
   override def registerUnpickler[T](key: String, p: Unpickler[T]): Unit =
     unpicklerMap.put(key, p)
 
+  override private[pickling] def clearRegisteredPicklerUnpicklerFor[T: FastTypeTag]: Unit = {
+    val tag = implicitly[FastTypeTag[T]]
+    picklerMap -= tag.key
+    unpicklerMap -= tag.key
+  }
+
   override val isLookupEnabled = true
 
   /** Checks the existence of a pickler ignoring the registered generators. */

--- a/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
+++ b/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
@@ -31,6 +31,7 @@ final class NoReflectionRuntime() extends PicklingRuntime {
     override def registerPicklerGenerator[T](typeConstructorKey: String, generator: (FastTypeTag[_]) => Pickler[T]): Unit = ()
     override def registerUnpickler[T](key: String, p: Unpickler[T]): Unit = ()
     override def registerPicklerUnpickler[T](key: String, p: Pickler[T] with Unpickler[T]): Unit = ()
+    override private[pickling] def clearRegisteredPicklerUnpicklerFor[T: FastTypeTag]: Unit = ()
   }
   override val refRegistry: RefRegistry = new DefaultRefRegistry()
   override val GRL: ReentrantLock = new ReentrantLock()

--- a/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
+++ b/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
@@ -20,6 +20,7 @@ final class NoReflectionRuntime() extends PicklingRuntime {
       throw new UnsupportedOperationException(s"Runtime pickler generation is disabled.  Cannot create unpickler for $tagKey")
     override def genPickler(classLoader: ClassLoader, clazz: Class[_], tag: FastTypeTag[_])(implicit share: Share): Pickler[_] =
       throw new UnsupportedOperationException(s"Runtime pickler generation is disabled.  Cannot create pickler for $tag")
+    override val isLookupEnabled: Boolean = false
     override def lookupUnpickler(key: String): Option[Unpickler[_]] = None
     override def lookupPickler(key: String): Option[Pickler[_]] = None
     override def lookupExistingPickler(key: String): Option[Pickler[_]] = None

--- a/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
@@ -98,5 +98,12 @@ trait PicklerRegistry {
     *                   this type.
     */
   def registerPicklerUnpicklerGenerator[T](typeConstructorKey: String, generator: FastTypeTag[_] => (Pickler[T] with Unpickler[T])): Unit
-  // TODO - Some kind of clean or inspect what we have?
+
+  /** Clear the registered pickler/unpickler for a given type.
+    *
+    * Useful for avoiding conflict between picklers registered with different
+    * sharing strategies and are cached when they're initialised.
+    */
+  private[pickling] def clearRegisteredPicklerUnpicklerFor[T: FastTypeTag]: Unit
+
 }

--- a/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
@@ -29,12 +29,15 @@ trait PicklerRegistry {
     */
   def genPickler(classLoader: ClassLoader, clazz: Class[_], tag: FastTypeTag[_])(implicit share: refs.Share): Pickler[_]
 
+  /** Checks if lookup is enabled for this registry */
+  def isLookupEnabled: Boolean
 
   /** Checks the existince of an unpickler.
     *
     * This will also check any registered generator functions.
     */
   def lookupUnpickler(key: String): Option[Unpickler[_]]
+
   /** Looks for a pickler with the given FastTypeTag string.
     *
     * This will also check any registered generator functions.

--- a/core/src/test/scala/pickling/run/share-binary-any.scala
+++ b/core/src/test/scala/pickling/run/share-binary-any.scala
@@ -6,6 +6,9 @@ import scala.pickling._, scala.pickling.Defaults._, binary._
 class C(val name: String, val desc: String, var c: C, val arr: Array[Int])
 
 class ShareBinaryAnyTest extends FunSuite {
+
+  import scala.pickling.internal.currentRuntime
+
   val c1 = new C("c1", "desc", null, Array(1))
   val c2 = new C("c2", "desc", c1, Array(1))
   val c3 = new C("c3", "desc", c2, Array(1))
@@ -31,6 +34,10 @@ class ShareBinaryAnyTest extends FunSuite {
   }*/
 
   test("loop-share-nothing") {
+
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[Any]
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[C]
+
     intercept[StackOverflowError] {
       import shareNothing._
       c1.c = c3
@@ -59,6 +66,9 @@ class ShareBinaryAnyTest extends FunSuite {
   }*/
 
   test("noloop-share-non-primitives") {
+
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[C]
+
     import shareNothing._
     c1.c = null
     val pickle = (c3: Any).pickle

--- a/core/src/test/scala/pickling/run/share-binary.scala
+++ b/core/src/test/scala/pickling/run/share-binary.scala
@@ -15,11 +15,17 @@ final class Simple(x: Int) {
 
 
 class ShareBinaryTest extends FunSuite {
+
+  import scala.pickling.internal.currentRuntime
+
   val c1 = new C("c1", "desc", null, Array(1))
   val c2 = new C("c2", "desc", c1, Array(1))
   val c3 = new C("c3", "desc", c2, Array(1))
 
   test("loop-share-nonprimitives") {
+
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[C]
+
     c1.c = c3
     val pickle = c1.pickle
     //val expected = "BinaryPickle([0,0,0,29,115,99,97,108,97,46,112,105,99,107,108,105,110,103,46,115,104,97,114,101,46,98,105,110,97,114,121,46,67,0,0,0,2,99,49,0,0,0,4,100,101,115,99,-5,0,0,0,2,99,51,0,0,0,4,100,101,115,99,-5,0,0,0,2,99,50,0,0,0,4,100,101,115,99,-3,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,1,1,0,0,0,0,0,0,1,1,0,0,0])"
@@ -42,6 +48,9 @@ class ShareBinaryTest extends FunSuite {
   }
 
   test("loop-share-nothing") {
+
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[C]
+
     intercept[StackOverflowError] {
       import shareNothing._
       c1.c = c3
@@ -50,6 +59,9 @@ class ShareBinaryTest extends FunSuite {
   }
 
   test("loop-share-everything") {
+
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[C]
+
     import shareEverything._
     c1.c = c3
     val pickle = c1.pickle
@@ -71,6 +83,9 @@ class ShareBinaryTest extends FunSuite {
   }
 
   test("noloop-share-non-primitives") {
+
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[C]
+
     import shareNothing._
     c1.c = null
     val pickle = c3.pickle

--- a/core/src/test/scala/pickling/run/share-json.scala
+++ b/core/src/test/scala/pickling/run/share-json.scala
@@ -6,10 +6,17 @@ import scala.pickling._, scala.pickling.Defaults._, json._
 class C(val name: String, val desc: String, var c: C, val arr: Array[Int])
 
 class ShareJsonTest extends FunSuite {
+
+  import scala.pickling.internal.currentRuntime
+
   val c1 = new C("c1", "desc", null, Array(1))
   val c2 = new C("c2", "desc", c1, Array(1))
   val c3 = new C("c3", "desc", c2, Array(1))
+
   test("loop-share-nonprimitives") {
+
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[C]
+
     c1.c = c3
     val pickle = c1.pickle
     assert(pickle.toString === """
@@ -56,12 +63,11 @@ class ShareJsonTest extends FunSuite {
   }
 
   test("loop-share-nothing") {
-    /*intercept[StackOverflowError] {
-      import shareNothing._
-      c1.c = c3
-      c2.pickle
-    }*/
-    // Note we've been running out of memory on this test in jenkins, which is also a legitimate success case
+
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[C]
+
+    // Note we've been running out of memory on this test in jenkins,
+    // which is also a legitimate success case
     try {
       import shareNothing._
       c1.c = c3
@@ -74,6 +80,9 @@ class ShareJsonTest extends FunSuite {
   }
 
   test("loop-share-everything") {
+
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[C]
+
     import shareEverything._
     c1.c = c3
     val pickle = c1.pickle
@@ -121,6 +130,9 @@ class ShareJsonTest extends FunSuite {
   }
 
   test("noloop-share-non-primitives") {
+
+    currentRuntime.picklers.clearRegisteredPicklerUnpicklerFor[C]
+
     import shareNothing._
     c1.c = null
     val pickle = c3.pickle


### PR DESCRIPTION
- Now, generated picklers/unpicklers are initialised only if there is no
  pickler/unpickler already registered for a given type. If that's the
  case, the registered on is reused.
- There's a special handling for the generation of both Pickler and
  Unpickler. We have to make sure that both pickler/unpickler exist and
  that they are the same one, since we have to return a class that
  matches the return type (`Pickler[T]` with `Unpickler[T]`).
- As a side note, it's necessary to cast `Unpickler`s and
  `Pickler with Unpickler` to `Generated`, otherwise the implicit search
  fails.
- Add a field in the `PicklerRegistry` that check if the lookup is
  enabled for every kind of registr.
