### PR TITLE
Force generation to create (un)picklers together

### DIFF
--- a/core/src/main/scala/scala/pickling/Pickler.scala
+++ b/core/src/main/scala/scala/pickling/Pickler.scala
@@ -26,7 +26,8 @@ trait Pickler[T] {
 // Shim for Java code.
 abstract class AbstractPickler[T] extends Pickler[T]
 object Pickler {
-  def generate[T]: Pickler[T] = macro generator.Compat.genPickler_impl[T]
+  @deprecated("Use `PicklerUnpickler.generate` instead", "0.11")
+  def generate[T]: Pickler[T] = macro generator.Compat.genPicklerUnpickler_impl[T]
 }
 
 /** A dynamic pickler for type `T`. Its `pickle` method takes an object-to-be-pickled of
@@ -82,7 +83,8 @@ trait Unpickler[T] {
 // Shim for Java code.
 abstract class AbstractUnpickler[T] extends Unpickler[T]
 object Unpickler {
-  def generate[T]: Unpickler[T] = macro generator.Compat.genUnpickler_impl[T]
+  @deprecated("Use `PicklerUnpickler.generate` instead", "0.11")
+  def generate[T]: Unpickler[T] = macro generator.Compat.genPicklerUnpickler_impl[T]
 }
 /* Shim for java code which wants to pickle/unpickle. */
 abstract class AbstractPicklerUnpickler[T] extends Pickler[T] with Unpickler[T]
@@ -90,7 +92,6 @@ object PicklerUnpickler {
   def apply[T](p: Pickler[T], u: Unpickler[T]): AbstractPicklerUnpickler[T] = new DelegatingPicklerUnpickler(p, u)
   //def generate[T]: Pickler[T] with Unpickler[T] = macro Compat.PicklerUnpicklerMacros_impl[T]
   def generate[T]: AbstractPicklerUnpickler[T] = macro generator.Compat.genPicklerUnpickler_impl[T]
-  def debugGenerate[T]: String = macro generator.Compat.genPicklerUnpickler_debug[T]
   /** This is a private implementation of PicklerUnpickler that delegates pickle and unpickle to underlying. */
   private class DelegatingPicklerUnpickler[T](p: Pickler[T], u: Unpickler[T]) extends AbstractPicklerUnpickler[T] {
     // From Pickler

--- a/core/src/main/scala/scala/pickling/generator/Compat.scala
+++ b/core/src/main/scala/scala/pickling/generator/Compat.scala
@@ -9,11 +9,6 @@ import scala.reflect.macros.Context
 import scala.reflect.runtime.{universe => ru}
 
 private[pickling] object Compat {
-  def genPickler_impl[T: c.WeakTypeTag](c: Context): c.Expr[Pickler[T] with Generated] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with PicklingMacros
-    c.Expr[Pickler[T] with Generated](bundle.genPickler[T])
-  }
 
   def genPicklerUnpickler_impl[T: c.WeakTypeTag](c: Context): c.Expr[AbstractPicklerUnpickler[T] with Generated] = {
     val c0: c.type = c
@@ -21,15 +16,4 @@ private[pickling] object Compat {
     c.Expr[AbstractPicklerUnpickler[T] with Generated](bundle.genPicklerUnpickler[T])
   }
 
-  def genUnpickler_impl[T: c.WeakTypeTag](c: Context): c.Expr[Unpickler[T] with Generated] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with PicklingMacros
-    c.Expr[Unpickler[T] with Generated](bundle.genUnPickler[T])
-  }
-
-  def genPicklerUnpickler_debug[T: c.WeakTypeTag](c: Context): c.Expr[String] = {
-    val c0: c.type = c
-    val bundle = new { val c: c0.type = c0 } with PicklingMacros
-    c.Expr[String](bundle.debugPicklerUnpickler[T])
-  }
 }

--- a/core/src/main/scala/scala/pickling/internal/AutoDefaultRuntimePicklers.scala
+++ b/core/src/main/scala/scala/pickling/internal/AutoDefaultRuntimePicklers.scala
@@ -1,7 +1,7 @@
 package scala.pickling
 package internal
 
-import scala.pickling.pickler.AnyUnpickler
+import scala.pickling.pickler.AnyPicklerUnpickler
 import scala.pickling.runtime.{Tuple2RTKnownTagUnpickler, Tuple2RTPickler}
 import scala.pickling.spi.PicklerRegistry
 
@@ -59,9 +59,9 @@ trait RuntimePicklerRegistryHelper extends PicklerRegistry {
   def tupleUnpicklerGenerator: FastTypeTag[_] => Unpickler[(Any,Any)] = {
     case FastTypeTag(_, List(left, right)) =>
       val lhs = 
-        currentRuntime.picklers.lookupUnpickler(left.toString).getOrElse(AnyUnpickler).asInstanceOf[Unpickler[Any]]
+        currentRuntime.picklers.lookupUnpickler(left.toString).getOrElse(AnyPicklerUnpickler).asInstanceOf[Unpickler[Any]]
       val rhs =
-        currentRuntime.picklers.lookupUnpickler(right.toString).getOrElse(AnyUnpickler).asInstanceOf[Unpickler[Any]]
+        currentRuntime.picklers.lookupUnpickler(right.toString).getOrElse(AnyPicklerUnpickler).asInstanceOf[Unpickler[Any]]
       new Tuple2RTKnownTagUnpickler(lhs, rhs)
     case tpe => new Tuple2RTPickler()
   }

--- a/core/src/main/scala/scala/pickling/pickler/Any.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Any.scala
@@ -9,7 +9,7 @@ import scala.reflect.runtime.currentMirror
   *
   * It will look up pickler/unpickler at runtime, or generate it.
   */
-object AnyPicklerUnpickler extends Pickler[Any] with Unpickler[Any]
+object AnyPicklerUnpickler extends AbstractPicklerUnpickler[Any]
     with AutoRegister[Any] {
 
   override def tag: FastTypeTag[Any] = FastTypeTag.Any

--- a/core/src/main/scala/scala/pickling/pickler/Any.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Any.scala
@@ -44,5 +44,5 @@ object AnyPicklerUnpickler extends AbstractPicklerUnpickler[Any]
 }
 
 trait AnyUnpicklers {
-  implicit val anyUnpickler: Unpickler[Any] = AnyPicklerUnpickler
+  implicit val anyPicklerUnpickler: AbstractPicklerUnpickler[Any] = AnyPicklerUnpickler
 }

--- a/core/src/main/scala/scala/pickling/pickler/Any.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Any.scala
@@ -1,34 +1,48 @@
 package scala.pickling
 package pickler
 
-/** An pickler for "Any" value (will look up pickler at runtime, or generate it. */
-object AnyPickler extends Pickler[Any] with AutoRegisterPickler[Any] {
+import scala.pickling.internal.GRL
+import scala.pickling.internal.currentRuntime
+import scala.reflect.runtime.currentMirror
+
+/** Generate a [[Pickler]] and [[Unpickler]] for [[Any]].
+  *
+  * It will look up pickler/unpickler at runtime, or generate it.
+  */
+object AnyPicklerUnpickler extends Pickler[Any] with Unpickler[Any]
+    with AutoRegister[Any] {
+
   override def tag: FastTypeTag[Any] = FastTypeTag.Any
+
+  /** Pickle [[Any]] by getting its class at runtime and looking
+    * up the correct [[Pickler]] for that class if available or
+    * generate it.
+    *
+    * Don't use [[AnyPicklerUnpickler]] for pickling classes with generic
+    * types. Otherwise, it will fail because of the type erasure
+    * and the lookup will replace the unknown type by [[Any]].
+    */
   override def pickle(picklee: Any, builder: PBuilder): Unit = {
-    // Here we just look up the pickler.
     val clazz = picklee.getClass
     val classLoader = this.getClass.getClassLoader
-    internal.GRL.lock()
+    GRL.lock()
     val tag = try FastTypeTag.makeRaw(clazz)
-    finally internal.GRL.unlock()
-    val p = internal.currentRuntime.picklers.genPickler(classLoader, clazz, tag)
+    finally GRL.unlock()
+    val p = currentRuntime.picklers.genPickler(classLoader, clazz, tag)
     p.asInstanceOf[Pickler[Any]].pickle(picklee, builder)
   }
-  override def toString = "AnyPickler"
-}
-/** An unpickler for "Any" value (will look up unpickler at runtime, or generate it. */
-object AnyUnpickler extends Unpickler[Any] with AutoRegisterUnpickler[Any] {
-  def tag: FastTypeTag[Any] = FastTypeTag.Any
+
+  /** Unpickle something as [[Any]] by looking up registered
+    * unpicklers for [[tag]] or using runtime unpickler generation.
+    */
   def unpickle(tag: String, reader: PReader): Any = {
-    val actualUnpickler = internal.currentRuntime.picklers.genUnpickler(scala.reflect.runtime.currentMirror, tag)
+    val actualUnpickler = currentRuntime.picklers.genUnpickler(currentMirror, tag)
     actualUnpickler.unpickle(tag, reader)
   }
-  override def toString = "AnyUnPickler"
+
+  override def toString = "AnyPicklerUnpickler"
 }
 
-/** Attempts to unpickle Any by looking up registered unpicklers using `currentMirror`.
- */
 trait AnyUnpicklers {
-  // Any
-  implicit val anyUnpickler: Unpickler[Any] = AnyUnpickler
+  implicit val anyUnpickler: Unpickler[Any] = AnyPicklerUnpickler
 }

--- a/core/src/main/scala/scala/pickling/pickler/GenPicklers.scala
+++ b/core/src/main/scala/scala/pickling/pickler/GenPicklers.scala
@@ -7,5 +7,6 @@ import scala.language.experimental.macros
  * See also `Pickler.generate`.
  */
 trait GenPicklers {
-  implicit def genPickler[T]: Pickler[T] = macro generator.Compat.genPickler_impl[T]
+  implicit def genPickler[T]: AbstractPicklerUnpickler[T] =
+    macro generator.Compat.genPicklerUnpickler_impl[T]
 }

--- a/core/src/main/scala/scala/pickling/pickler/GenUnpicklers.scala
+++ b/core/src/main/scala/scala/pickling/pickler/GenUnpicklers.scala
@@ -9,5 +9,6 @@ trait GenOpenSumUnpicklers {
 }
 
 trait GenUnpicklers extends GenOpenSumUnpicklers {
-  implicit def genUnpickler[T]: Unpickler[T] with Generated = macro generator.Compat.genUnpickler_impl[T  ]
+  implicit def genUnpickler[T]: AbstractPicklerUnpickler[T] with Generated =
+    macro generator.Compat.genPicklerUnpickler_impl[T  ]
 }

--- a/core/src/main/scala/scala/pickling/pickler/Iterable.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Iterable.scala
@@ -53,11 +53,11 @@ object TravPickler {
   def generate[T, C](cbf: CanBuildFrom[C,T,C], asTraversable: C => Traversable[_])(elementTagExtractor: FastTypeTag[_] => FastTypeTag[T])(tpe: FastTypeTag[_]): AbstractPicklerUnpickler[C] = {
     val elementType = elementTagExtractor(tpe)
     val elemPickler =
-      if(elementType.key == ANY_TAG.key) AnyPickler
+      if(elementType.key == ANY_TAG.key) AnyPicklerUnpickler
       else currentRuntime.picklers.lookupPickler(elementType.key).getOrElse(
         throw new PicklingException(s"Cannnot generate a pickler/unpickler for $tpe, cannot find a pickler for $elementType"))
     val elemUnpickler =
-      if(elementType.key == ANY_TAG.key) AnyUnpickler
+      if(elementType.key == ANY_TAG.key) AnyPicklerUnpickler
       else currentRuntime.picklers.lookupUnpickler(elementType.key).getOrElse(
         throw new PicklingException(s"Cannnot generate a pickler/unpickler for $tpe, cannot find an unpickler for $elementType"))
     val colTag = tpe

--- a/core/src/main/scala/scala/pickling/pickler/Primitives.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Primitives.scala
@@ -1,8 +1,11 @@
 package scala.pickling
 package pickler
 
-/** Picklers for primitive types.
- */
+/** Generate [[Pickler]]s and [[Unpickler]]s for the primitive types.
+  *
+  * The primitive types are [[Byte]], [[Short]], [[Char]], [[Int]], [[Long]],
+  * [[Boolean]], [[Float]], [[Double]], [[Null]], [[String]] and [[Unit]].
+  */
 trait PrimitivePicklers {
   implicit val bytePickler: Pickler[Byte] with Unpickler[Byte] = PrimitivePickler[Byte]
   implicit val shortPickler: Pickler[Short] with Unpickler[Short] = PrimitivePickler[Short]
@@ -27,14 +30,16 @@ class PrimitivePickler[T: FastTypeTag](name: String)
   }
   override def unpickle(tag: String, reader: PReader): Any = {
     try {
-      // TODO - beginEntry/endEntry?
-      reader.readPrimitive()
-    } catch {
-      case PicklingException(msg, cause) =>
-        throw PicklingException(s"""error in unpickle of primitive unpickler '$name':
-                                   |tag in unpickle: '${tag}'
-                                   |message:
-                                   |$msg""".stripMargin, cause)
+      reader.beginEntry()
+      val readValue = reader.readPrimitive()
+      reader.endEntry()
+      readValue
+    } catch { case PicklingException(msg, cause) =>
+        throw PicklingException(
+          s"""error in unpickle of primitive unpickler '$name':
+             |tag in unpickle: '${tag}'
+             |message:
+             |$msg""".stripMargin, cause)
     }
   }
 }

--- a/core/src/main/scala/scala/pickling/pickler/Primitives.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Primitives.scala
@@ -30,10 +30,11 @@ class PrimitivePickler[T: FastTypeTag](name: String)
   }
   override def unpickle(tag: String, reader: PReader): Any = {
     try {
-      reader.beginEntry()
-      val readValue = reader.readPrimitive()
-      reader.endEntry()
-      readValue
+      // Don't use beginEntry/endEntry because
+      // tag has to be elided and there's some
+      // incompatibilities between java and scala
+      // primitive types (like String or Int)
+      reader.readPrimitive()
     } catch { case PicklingException(msg, cause) =>
         throw PicklingException(
           s"""error in unpickle of primitive unpickler '$name':

--- a/core/src/test/scala/pickling/run/issue409.scala
+++ b/core/src/test/scala/pickling/run/issue409.scala
@@ -1,0 +1,19 @@
+package scala.pickling.generation
+
+import org.scalatest.FunSuite
+import scala.pickling._, Defaults._, json._
+
+class CheckGenPicklerUnpicklerTogether extends FunSuite {
+
+  case class Pi(number: Int)
+
+  test("check that pickler and unpickler are generated together (I)") {
+
+    val p = implicitly[Pickler[Pi]]
+    val u = implicitly[Unpickler[Pi]]
+
+    assert(p === u)
+
+  }
+
+}

--- a/core/src/test/scala/pickling/run/sealed-trait-static-annotated.scala
+++ b/core/src/test/scala/pickling/run/sealed-trait-static-annotated.scala
@@ -1,6 +1,6 @@
 package scala.pickling.test.sealedtraitstaticannotated
 
-import scala.pickling.{PicklingException, directSubclasses, Pickler, Unpickler, Defaults }
+import scala.pickling._
 import scala.pickling.static._
 import scala.pickling.json._
 import Defaults.{ stringPickler, intPickler, refUnpickler, nullPickler }
@@ -13,15 +13,13 @@ import org.scalatest.FunSuite
 trait Fruit
 
 object Banana {
-  implicit val pickler = Defaults.genPickler[Banana]
-  implicit val unpickler = Defaults.genUnpickler[Banana]
+  implicit val picklerUnpickler = Defaults.genPickler[Banana]
 }
 
 // this is BEFORE the subtypes below so directKnownSubclasses probably
 // won't work and this would break without the directSubclasses annotation.
 object Fruit {
-  implicit val pickler = Defaults.genPickler[Fruit]
-  implicit val unpickler = Defaults.genUnpickler[Fruit]
+  implicit val picklerUnpickler = Defaults.genPickler[Fruit]
 }
 
 sealed trait RedOrOrangeFruit extends Fruit
@@ -86,8 +84,7 @@ class SealedTraitStaticAnnotatedTest extends FunSuite {
   }
 
   test("manually generate") {
-    implicit val pumpkinPickler = Pickler.generate[Pumpkin]
-    implicit val pumpkinUnpickler = Unpickler.generate[Pumpkin]
+    implicit val pumpkinPicklerUnpickler = PicklerUnpickler.generate[Pumpkin]
     val pumpkin = Pumpkin("Kabocha")
     val pumpkinString = pumpkin.pickle.value
     assert(JSONPickle(pumpkinString).unpickle[Pumpkin] == pumpkin)

--- a/core/src/test/scala/pickling/run/sealed-trait-static.scala
+++ b/core/src/test/scala/pickling/run/sealed-trait-static.scala
@@ -1,6 +1,6 @@
 package scala.pickling.test.sealedtraitstatic
 
-import scala.pickling.{ Pickler, Unpickler, PicklingException }
+import scala.pickling.{PicklerUnpickler, Pickler, Unpickler, PicklingException}
 import scala.pickling.static._
 import scala.pickling.json._
 import scala.pickling.Defaults._
@@ -18,8 +18,7 @@ final case class Banana(something: Int) extends Fruit
 final case class Cucumber(something: Int) // does not extend Fruit but same shape as Banana
 
 object Fruit {
-  implicit val pickler = Pickler.generate[Fruit]
-  implicit val unpickler = Unpickler.generate[Fruit]
+  implicit val picklerUnpickler = PicklerUnpickler.generate[Banana]
 }
 
 class SealedTraitStaticTest extends FunSuite {

--- a/core/src/test/scala/pickling/run/share-binary-any.scala
+++ b/core/src/test/scala/pickling/run/share-binary-any.scala
@@ -40,6 +40,7 @@ class ShareBinaryAnyTest extends FunSuite {
 
     intercept[StackOverflowError] {
       import shareNothing._
+      implicit val pu = PicklerUnpickler.generate[C]
       c1.c = c3
       (c2: Any).pickle
     }


### PR DESCRIPTION
- Macros generate `Pickler[T]`/`Unpickler[T]` together instead of
  creating them separately. This reduces final code size since now
  there's only one class instead of two and also improves the reuse of
  already generated picklers (see issue #409).
- As now the return type of the implicit method is
  `AbstractPicklerUnpickler`, there can be some errors because of
  ambiguous implicit values (e.g. sealed-trait-static) when (un)picklers
  are explicitly called via `generate`. The fix is to only use
  `PicklerUnpickler.generate` and deprecate separate explicit creation
  with `Pickler.generate` and `Unpickler.generate`.
- Make `Any` and `Either` to generate pickler/unpickler together.
- Improve documentation by adding more concrete explanations.
