### PR TITLE
Fix #415 - initialization of pickler registry when switching runtime strategies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._ // see project/Dependencies.scala
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-val buildVersion = "0.11.0-SNAPSHOT"
+val buildVersion = "0.11.0-M4"
 
 def commonSettings = Seq(
   version in ThisBuild := buildVersion,
@@ -58,7 +58,7 @@ def noPublish = Seq(
 
 // Use root project
 lazy val root: Project = (project in file(".")).
-  aggregate(core, benchmark, sandbox, macroTests).
+  aggregate(core, benchmark, sandbox, sandboxTests, macroTests).
   settings(commonSettings ++ noPublish: _*).
   settings(
     name := "Scala Pickling",
@@ -124,6 +124,18 @@ lazy val sandbox: Project = (project in file("sandbox")).
     // scalacOptions ++= Seq()
     scalacOptions ++= Seq("-Xlog-implicits")
     // scalacOptions ++= Seq("-Xprint:typer")
+  )
+
+/* This submodule is meant to store tests that need to be executed
+ * independently from the main test suite placed in `core`. */
+lazy val sandboxTests: Project = (project in file("sandbox-test")).
+  dependsOn(core).
+  settings(commonSettings ++ noPublish: _*).
+  settings(
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+      scalaTest
+    )
   )
 
 lazy val benchmark: Project = (project in file("benchmark")).

--- a/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
+++ b/core/src/main/scala/scala/pickling/internal/NoReflectionRuntime.scala
@@ -4,7 +4,6 @@ package internal
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.pickling.refs.Share
-import scala.pickling.{Pickler, Unpickler, FastTypeTag}
 import scala.pickling.spi.{PicklerRegistry, RefRegistry, PicklingRuntime}
 import scala.reflect.runtime
 
@@ -32,6 +31,7 @@ final class NoReflectionRuntime() extends PicklingRuntime {
     override def registerUnpickler[T](key: String, p: Unpickler[T]): Unit = ()
     override def registerPicklerUnpickler[T](key: String, p: Pickler[T] with Unpickler[T]): Unit = ()
     override private[pickling] def clearRegisteredPicklerUnpicklerFor[T: FastTypeTag]: Unit = ()
+    override private[pickling] def dumpStateTo(r: scala.pickling.spi.PicklerRegistry): Unit = ()
   }
   override val refRegistry: RefRegistry = new DefaultRefRegistry()
   override val GRL: ReentrantLock = new ReentrantLock()

--- a/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
+++ b/core/src/main/scala/scala/pickling/spi/PicklerRegistry.scala
@@ -106,4 +106,13 @@ trait PicklerRegistry {
     */
   private[pickling] def clearRegisteredPicklerUnpicklerFor[T: FastTypeTag]: Unit
 
+  /** Transfer the "state" between different [[PicklingRuntime]]s.
+    *
+    * Watch out, this operation is not thread-safe.
+    *
+    * Make a new [[PicklingRuntime]] aware of the already registered [[Pickler]]s
+    * and [[Unpickler]]s present in the one that will be replaced.
+    */
+  private[pickling] def dumpStateTo(r: PicklerRegistry): Unit
+
 }

--- a/sandbox-test/src/test/scala/scala/pickling/registry/SwitchRuntimeRegistryInit.scala
+++ b/sandbox-test/src/test/scala/scala/pickling/registry/SwitchRuntimeRegistryInit.scala
@@ -1,0 +1,44 @@
+package scala.pickling.registry
+
+import org.scalatest.FunSuite
+
+import scala.pickling._
+import scala.pickling.internal.HybridRuntime
+import scala.pickling.json.JsonFormats
+import scala.pickling.pickler.AllPicklers
+
+object Protocol extends {
+  val oldRuntime = internal.currentRuntime
+  val currentRuntime = new HybridRuntime
+  val onlyLookup = internal.replaceRuntime(currentRuntime)
+} with Ops with AllPicklers with JsonFormats
+
+class SwitchRuntimeRegistryInit extends FunSuite {
+
+  import Protocol._
+
+  test("registry should be initialized when switching runtime strategies") {
+
+    case class Foo(i: Int)
+    val pf = implicitly[AbstractPicklerUnpickler[Foo]]
+    
+    // If the test passes, this should not initialize
+    // the registry again. If it fails it does.
+    implicitly[Pickler[List[String]]]
+
+    try {
+    val lookup = currentRuntime.picklers.lookupPickler(pf.tag.key)
+    assert(lookup !== None)
+
+    val pf2 = implicitly[AbstractPicklerUnpickler[Foo]]
+    val lookup2 = currentRuntime.picklers.lookupPickler(pf.tag.key)
+    assert(lookup === lookup2)
+    } finally {
+      internal.replaceRuntime(oldRuntime)
+      // Just in case it doesn't get init
+      implicitly[Pickler[List[String]]]
+    }
+
+  }
+
+}


### PR DESCRIPTION
- Now, every time we change the runtime, we pass its state if the
  runtime allows lookups. The state is composed by the registered
  picklers and unpicklers.
- Add documentation for every new method.
- Remove some unused imports.

/cc @jsuereth 
