### PR TITLE
Add pickler and unpickler for Nothing

### DIFF
--- a/core/src/main/scala/scala/pickling/PicklingErrors.scala
+++ b/core/src/main/scala/scala/pickling/PicklingErrors.scala
@@ -178,4 +178,8 @@ object PicklingErrors {
   final case class Wrapper(e: Throwable, msg: String, delimiter: String = "\n")
     extends BasePicklingException(s"$msg$delimiter${e.getMessage}", Some(e))
 
+  /** Exception thrown when one tries to unpickle on a Unpickler[Nothing]. */
+  case object NothingIsNotUnpicklable extends PicklingRuntimeException(
+    s"You called `unpickle` on `Unpickler[Nothing]`, but it cannot be unpickled")
+
 }

--- a/core/src/main/scala/scala/pickling/pickler/AllPicklerUnpicklers.scala
+++ b/core/src/main/scala/scala/pickling/pickler/AllPicklerUnpicklers.scala
@@ -4,6 +4,7 @@ package pickler
 /** All pickler instances, including the low priority implicits. */
 trait AllPicklers extends LowPriorityPicklers
   with PrimitivePicklers
+  with NothingPicklers
   with DatePicklers
   with JavaBigDecimalPicklers
   with JavaBigIntegerPicklers

--- a/core/src/main/scala/scala/pickling/pickler/Nothing.scala
+++ b/core/src/main/scala/scala/pickling/pickler/Nothing.scala
@@ -1,0 +1,16 @@
+package scala.pickling.pickler
+
+import scala.pickling._
+import PicklingErrors.NothingIsNotUnpicklable
+
+trait NothingPicklers {
+  implicit object NothingPicklerUnpickler extends AbstractPicklerUnpickler[Nothing] {
+    override def tag: FastTypeTag[Nothing] = FastTypeTag.Nothing
+    /** Impossible to call in Scala, no value can be typed [[Nothing]] */
+    override def pickle(picklee: Nothing, builder: PBuilder): Unit = ???
+    /** Don't call [[unpickle]], [[Nothing]] cannot be unpickled. */
+    override def unpickle(tag: String, reader: PReader): Any =
+      throw NothingIsNotUnpicklable
+  }
+}
+

--- a/core/src/test/scala/scala/pickling/binary/NullBinaryTest.scala
+++ b/core/src/test/scala/scala/pickling/binary/NullBinaryTest.scala
@@ -13,7 +13,6 @@ class NullBinaryTest extends FunSuite {
     implicit val pd = implicitly[AbstractPicklerUnpickler[D]]
     implicit val pc = implicitly[AbstractPicklerUnpickler[C]]
     val pickle = c.pickle
-    println(pickle)
     assert(pickle.value.mkString("[", ",", "]") === "[0,0,0,28,115,99,97,108,97,46,112,105,99,107,108,105,110,103,46,110,117,108,108,46,98,105,110,97,114,121,46,67,-2,0,0,0,0,-2]")
     assert(pickle.unpickle[C].toString === c.toString)
   }

--- a/core/src/test/scala/scala/pickling/runtime/NothingPickleUnpickleTest.scala
+++ b/core/src/test/scala/scala/pickling/runtime/NothingPickleUnpickleTest.scala
@@ -1,0 +1,23 @@
+package scala.pickling.runtime
+
+import org.scalatest.FunSuite
+
+import scala.pickling.Defaults._
+import scala.pickling.json._
+
+import scala.pickling.AbstractPicklerUnpickler
+import scala.pickling.PicklingErrors.NothingIsNotUnpicklable
+
+class NothingPickleUnpickleTest extends FunSuite {
+
+  val nothingPU = implicitly[AbstractPicklerUnpickler[Nothing]]
+
+  // `pickle` cannot simply be called, only test `unpickle`
+  test("unpickle `Nothing` throws an exception") {
+    intercept[NothingIsNotUnpicklable.type] {
+      val reader = pickleFormat.createReader(JSONPickle("{}"))
+      nothingPU.unpickle("", reader)
+    }
+  }
+
+}


### PR DESCRIPTION
- Add picklers for Nothing, `pickle` cannot be actually called. Reuse
  `FastTypeTag[Nothing]`, which was already defined. Include the
  picklers in `Defaults`.
- Add error in case the `unpickle` method is called.
- Remove annoying println in test `NullBinaryTest`.
