### PR TITLE
Experiment to compile to 2.12 and cross to 2.11, drop 2.10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ scala:
   - 2.12.2
   - 2.11.11
 jdk:
-  - openjdk7
-  - oraclejdk7
+  - oraclejdk8
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ cache:
 language: scala
 
 scala:
-  - 2.11.8
-  - 2.10.6
+  - 2.12.2
+  - 2.11.11
 jdk:
   - openjdk7
   - oraclejdk7

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._ // see project/Dependencies.scala
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-val buildVersion = "0.11.0-M2"
+val buildVersion = "0.12.0"
 
 def commonSettings = Seq(
   version in ThisBuild := buildVersion,
@@ -13,6 +13,7 @@ def commonSettings = Seq(
     case "2.10" => Seq("-Xmax-classfile-name", "254")
     case _ => Seq()
   }),
+  scalacOptions ++= Seq("-deprecation"),
   organization in ThisBuild := "org.scala-lang.modules",
   organizationName in ThisBuild := "LAMP/EPFL",
   organizationHomepage in ThisBuild := Some(url("http://lamp.epfl.ch")),
@@ -143,7 +144,11 @@ lazy val benchmark: Project = (project in file("benchmark")).
   dependsOn(core).
   settings(commonSettings ++ noPublish ++ benchmarkSettings: _*).
   settings(
-    scalacOptions ++= Seq("-optimise"),
+    // -optimise is deprecated: In 2.12,
+    // -optimise enables -opt:l:classpath.
+    // Check -opt:help for using the Scala 2.12 optimizer.
+    //scalacOptions ++= Seq("-optimise"),
+    scalacOptions ++= Seq("-Xlog-implicits"),
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
       kryoSerializers, kryo)

--- a/core/src/main/scala/scala/pickling/Compat.scala
+++ b/core/src/main/scala/scala/pickling/Compat.scala
@@ -2,8 +2,7 @@ package scala.pickling
 
 import scala.language.experimental.macros
 import scala.language.existentials
-
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.reflect.runtime.{universe => ru}
 
 // this is only necessary because 2.10.x doesn't support macro bundles

--- a/core/src/main/scala/scala/pickling/Macros.scala
+++ b/core/src/main/scala/scala/pickling/Macros.scala
@@ -50,8 +50,8 @@ trait PickleMacros extends Macro with TypeAnalysis {
     val tpe = weakTypeOf[T]
     val q"${_}($pickleeArg)" = c.prefix.tree
     val endPickle = if (shouldBotherAboutCleaning(tpe)) q"clearPicklees()" else q"";
-    val pickleeName = newTermName("picklee$pickleTo$")
-    val builderName = newTermName("builder$pickleTo$")
+    val pickleeName = TermName("picklee$pickleTo$")
+    val builderName = TermName("builder$pickleTo$")
     q"""
       import _root_.scala.pickling._
       import _root_.scala.pickling.internal._

--- a/core/src/main/scala/scala/pickling/PicklingErrors.scala
+++ b/core/src/main/scala/scala/pickling/PicklingErrors.scala
@@ -17,7 +17,7 @@ private[pickling] object Feedback {
 
 private[pickling] object MacrosErrors {
 
-  import scala.reflect.macros.Context
+  import scala.reflect.macros.whitebox.Context
 
   def failedGeneration(culprit: String)(implicit c: Context, l: AlgorithmLogger): Nothing = {
     l.error(s"Failed pickler/unpickler generation for $culprit")

--- a/core/src/main/scala/scala/pickling/binary/Util.scala
+++ b/core/src/main/scala/scala/pickling/binary/Util.scala
@@ -2,8 +2,9 @@ package scala.pickling.binary
 
 object UnsafeMemory {
   import sun.misc.Unsafe
-  private[pickling] val unsafe: Unsafe =
-  scala.concurrent.util.Unsafe.instance
+  import scala.pickling.Tools
+  //private[pickling] val unsafe: Unsafe = scala.concurrent.util.Unsafe.instance
+  private[pickling] val unsafe: Unsafe = Tools.unsafe
   private[pickling] val byteArrayOffset: Long = unsafe.arrayBaseOffset(classOf[Array[Byte]])
   private[pickling] val shortArrayOffset: Long = unsafe.arrayBaseOffset(classOf[Array[Short]])
   private[pickling] val intArrayOffset: Long = unsafe.arrayBaseOffset(classOf[Array[Int]])

--- a/core/src/main/scala/scala/pickling/binary/Util.scala
+++ b/core/src/main/scala/scala/pickling/binary/Util.scala
@@ -3,7 +3,6 @@ package scala.pickling.binary
 object UnsafeMemory {
   import sun.misc.Unsafe
   import scala.pickling.Tools
-  //private[pickling] val unsafe: Unsafe = scala.concurrent.util.Unsafe.instance
   private[pickling] val unsafe: Unsafe = Tools.unsafe
   private[pickling] val byteArrayOffset: Long = unsafe.arrayBaseOffset(classOf[Array[Byte]])
   private[pickling] val shortArrayOffset: Long = unsafe.arrayBaseOffset(classOf[Array[Short]])

--- a/core/src/main/scala/scala/pickling/generator/Compat.scala
+++ b/core/src/main/scala/scala/pickling/generator/Compat.scala
@@ -4,8 +4,7 @@ package generator
 import scala.language.experimental.macros
 import scala.language.existentials
 import scala.pickling.Pickler
-
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.reflect.runtime.{universe => ru}
 
 private[pickling] object Compat {

--- a/core/src/main/scala/scala/pickling/generator/sourcegen.scala
+++ b/core/src/main/scala/scala/pickling/generator/sourcegen.scala
@@ -356,7 +356,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
 
   def genAllocateInstance(x: AllocateInstance): c.Tree = {
     val tpe = x.tpe.tpe[c.universe.type](c.universe)
-    q"""_root_.scala.picking.Tools.unsafe.allocateInstance(classOf[$tpe]).asInstanceOf[$tpe]"""
+    q"""_root_.scala.pickling.Tools.unsafe.allocateInstance(classOf[$tpe]).asInstanceOf[$tpe]"""
   }
 
   def generateUnpickleImplFromAst(unpicklerAst: UnpicklerAst): c.Tree = {
@@ -484,7 +484,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
     val objectOutTpe = typeOf[scala.pickling.util.GenObjectOutput]
     val fieldName = "$ext"
     q"""
-       val $target = _root_.scala.picking.Tools.unsafe.allocateInstance(classOf[$tpe]).asInstanceOf[$tpe]
+       val $target = _root_.scala.pickling.Tools.unsafe.allocateInstance(classOf[$tpe]).asInstanceOf[$tpe]
        val $readerName = reader.readField($fieldName)
        val out = {
          val up = _root_.scala.Predef.implicitly[_root_.scala.pickling.Unpickler[$objectOutTpe]]

--- a/core/src/main/scala/scala/pickling/generator/sourcegen.scala
+++ b/core/src/main/scala/scala/pickling/generator/sourcegen.scala
@@ -356,7 +356,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
 
   def genAllocateInstance(x: AllocateInstance): c.Tree = {
     val tpe = x.tpe.tpe[c.universe.type](c.universe)
-    q"""_root_.scala.concurrent.util.Unsafe.instance.allocateInstance(classOf[$tpe]).asInstanceOf[$tpe]"""
+    q"""_root_.scala.picking.Tools.unsafe.allocateInstance(classOf[$tpe]).asInstanceOf[$tpe]"""
   }
 
   def generateUnpickleImplFromAst(unpicklerAst: UnpicklerAst): c.Tree = {
@@ -484,7 +484,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
     val objectOutTpe = typeOf[scala.pickling.util.GenObjectOutput]
     val fieldName = "$ext"
     q"""
-       val $target = _root_.scala.concurrent.util.Unsafe.instance.allocateInstance(classOf[$tpe]).asInstanceOf[$tpe]
+       val $target = _root_.scala.picking.Tools.unsafe.allocateInstance(classOf[$tpe]).asInstanceOf[$tpe]
        val $readerName = reader.readField($fieldName)
        val out = {
          val up = _root_.scala.Predef.implicitly[_root_.scala.pickling.Unpickler[$objectOutTpe]]

--- a/core/src/main/scala/scala/pickling/generator/sourcegen.scala
+++ b/core/src/main/scala/scala/pickling/generator/sourcegen.scala
@@ -27,7 +27,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
 
     def genGetField(x: GetField): c.Tree = {
       def pickleLogic(isStaticallyElided: Boolean, fieldValue: Tree, tpe: Type): Tree = {
-        val fieldPickler = c.fresh(newTermName("fieldPickler"))
+        val fieldPickler = c.freshName(TermName("fieldPickler"))
         val elideHint =
           if (isStaticallyElided) q"b.hintElidedType($fieldPickler.tag)" else q""
         // NOTE; This will look up an IMPLICIT pickler for the value, based on the type.
@@ -48,12 +48,12 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
           if(x.isScala || !x.isPublic) {
             // We always have to use reflection for scala fields right now.  Additionally, for Scala fields, we
             // actually have no idea if they exist at runtime, so we allow failure for now, which is EVIL, but we have no alternative.
-            val result = reflectivelyGet(newTermName("picklee"), x)(fm => fm)
-            val rTerm = c.fresh(newTermName("result"))
+            val result = reflectivelyGet(TermName("picklee"), x)(fm => fm)
+            val rTerm = c.freshName(TermName("result"))
             val logic = q"""val $rTerm = { ..$result }
                             ${putField(q"$rTerm.asInstanceOf[$tpe]", staticallyElided, tpe)}"""
             if(x.isScala) allowNonExistentField(logic) else logic
-          } else putField(q"picklee.${newTermName(x.fieldName)}", staticallyElided, tpe)
+          } else putField(q"picklee.${TermName(x.fieldName)}", staticallyElided, tpe)
         case _: IrConstructor =>
           // This is a logic erorr
           sys.error(s"Pickling logic error.  Found constructor when trying to pickle field ${x.name}.")
@@ -63,9 +63,9 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
             // TODO - This is too naive of a determination.  In practice, we almost want an "always elide" and "never elide" mode.
             tpe.isEffectivelyFinal || tpe.isEffectivelyPrimitive
           }
-          if (y.isPublic) putField(q"picklee.${newTermName(y.methodName)}", staticallyElided, tpe)
+          if (y.isPublic) putField(q"picklee.${TermName(y.methodName)}", staticallyElided, tpe)
           else {
-            val result = reflectivelyGet(newTermName("picklee"), y)(fm => putField(q"${fm}.asInstanceOf[${y.returnType(u).asInstanceOf[c.Type]}]", staticallyElided, tpe))
+            val result = reflectivelyGet(TermName("picklee"), y)(fm => putField(q"${fm}.asInstanceOf[${y.returnType(u).asInstanceOf[c.Type]}]", staticallyElided, tpe))
             q"""..$result"""
           }
       }
@@ -76,12 +76,12 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
 
     def genSubclassDispatch(x: SubclassDispatch): c.Tree = {
       val tpe = x.parent.tpe[c.universe.type](c.universe)
-      val clazz = newTermName("clazz")
+      val clazz = TermName("clazz")
       val compileTimeDispatch: List[CaseDef] =
         (x.subClasses map { subtpe =>
           val tpe = subtpe.tpe[c.universe.type](c.universe)
           CaseDef(
-            Bind(clazz, Ident(nme.WILDCARD)),
+            Bind(clazz, Ident(termNames.WILDCARD)),
             q"_root_.scala.pickling.util.ClassMapper.areSameClasses($clazz, classOf[$tpe])",
             createPickler(tpe, q"builder")
           )
@@ -89,16 +89,16 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
 
       val failDispatch = {
         val dispatcheeNames = x.subClasses.map(_.className).mkString(", ")
-        val otherTermName = newTermName("other")
+        val otherTermName = TermName("other")
         val throwUnknownTag =
           if(x.subClasses.isEmpty) {
             q"""throw $unrecognizedClass(clazz, None)"""
           } else
             q"""throw $unrecognizedClass(clazz,
                Some("looking for one of: " + $dispatcheeNames))"""
-        CaseDef(Bind(otherTermName, Ident(nme.WILDCARD)), throwUnknownTag)
+        CaseDef(Bind(otherTermName, Ident(termNames.WILDCARD)), throwUnknownTag)
       }
-      val runtimeDispatch = CaseDef(Ident(nme.WILDCARD), EmptyTree, createRuntimePickler(q"builder"))
+      val runtimeDispatch = CaseDef(Ident(termNames.WILDCARD), EmptyTree, createRuntimePickler(q"builder"))
       val unknownDispatch =
         if(x.lookupRuntime) List(runtimeDispatch)
         else List(failDispatch)
@@ -125,7 +125,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
     def genPickleEntry(op: PickleEntry): c.Tree = {
       val nested =
         op.ops.toList map genPickleOp
-      val oid = c.fresh(newTermName("oid"))
+      val oid = c.freshName(TermName("oid"))
       // TODO - hint known size
       val shareHint: List[c.Tree] =
         if(shareNothing) List(q"()")
@@ -146,7 +146,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
         case x: GetField => genGetField(x)
         case x: PickleEntry => genPickleEntry(x)
         case x: SubclassDispatch => genSubclassDispatch(x)
-        case x: PickleExternalizable => genExternalizablePickle(newTermName("picklee"), newTermName("builder"), x)
+        case x: PickleExternalizable => genExternalizablePickle(TermName("picklee"), TermName("builder"), x)
       }
     genPickleOp(picklerAst)
   }
@@ -200,12 +200,12 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
   }
 
   def readField(name: String, tpe: Type): c.Tree = {
-    val readerName = c.fresh(newTermName("reader"))
-    val unpicklerName    = c.fresh(newTermName("unpickler$unpickle$"))
+    val readerName = c.freshName(TermName("reader"))
+    val unpicklerName    = c.freshName(TermName("unpickler$unpickle$"))
     // TODO - is this the right place to do this?
     val staticHint       = if (tpe.isEffectivelyFinal) q"$readerName.hintElidedType($unpicklerName.tag)" else q"";
 
-    val resultName = c.fresh(newTermName("result"))
+    val resultName = c.freshName(TermName("result"))
     // TODO - may be able to drop locally.
       q"""
          _root_.scala.Predef.locally {
@@ -262,9 +262,9 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
     // TODO - Handle reflective case.
     val result = if(cons.requiresReflection) sys.error(s"Unable to reflectively call factory methods, currently.")
     else {
-      if(cons.factoryMethod.parameterNames.isEmpty) q"${tpe}.${newTermName(cons.factoryMethod.methodName)}()"
+      if(cons.factoryMethod.parameterNames.isEmpty) q"${tpe}.${TermName(cons.factoryMethod.methodName)}()"
       else {
-        q"${tpe}.${newTermName(cons.factoryMethod.methodName)}(...$argss)"
+        q"${tpe}.${TermName(cons.factoryMethod.methodName)}(...$argss)"
       }
     }
     result
@@ -282,9 +282,9 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
             val read = readField(s.name, tpe)
             if(x.isPublic) {
               q"""
-                 result.${newTermName(x.methodName)}($read)
+                 result.${TermName(x.methodName)}($read)
                """
-            } else reflectivelySet(newTermName("result"), x, read)
+            } else reflectivelySet(TermName("result"), x, read)
           case x => sys.error(s"Cannot handle a setting method that does not take exactly one parameter, found parameters: $x")
         }
 
@@ -293,8 +293,8 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
         val read = readField(s.name, tpe)
         val staticallyElided = tpe.isEffectivelyFinal || tpe.isEffectivelyPrimitive
         if(x.isScala || !x.isPublic || x.isFinal) {
-          reflectivelySet(newTermName("result"), x, read)
-        } else q"""result.${newTermName(x.fieldName)} = $read"""
+          reflectivelySet(TermName("result"), x, read)
+        } else q"""result.${TermName(x.fieldName)} = $read"""
     }
 
   }
@@ -327,9 +327,9 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
     val tpe = x.parent.tpe[c.universe.type](c.universe)
     val defaultCase =
       if(x.lookupRuntime)
-        CaseDef(Ident(nme.WILDCARD), EmptyTree,
+        CaseDef(Ident(termNames.WILDCARD), EmptyTree,
           q"_root_.scala.pickling.internal.`package`.currentRuntime.picklers.genUnpickler(_root_.scala.pickling.internal.`package`.currentMirror, tagKey)")
-      else CaseDef(Ident(nme.WILDCARD), EmptyTree,
+      else CaseDef(Ident(termNames.WILDCARD), EmptyTree,
         q"""throw $unrecognizedTagPath(tagKey, "unpickling")""")
     val subClassCases =
        x.subClasses.toList map { sc =>
@@ -368,7 +368,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
       case x: UnpickleSingleton => genUnpickleSingleton(x)
       case x: AllocateInstance => genAllocateInstance(x)
         // TODO - This is kind of hacky, should be a temproary workaround for a better solution.
-      case x: UnpickleExternalizable => genExternalizablUnPickle(newTermName("reader"), x)
+      case x: UnpickleExternalizable => genExternalizablUnPickle(TermName("reader"), x)
       case x: UnpickleBehavior =>
         val behavior = x.operations.map(generateUnpickleImplFromAst).toList
         // TODO - This is kind of hacky.  We're trying to make sure during unpickling we always register/unregister appropriately...
@@ -415,7 +415,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
   def generatePicklerUnpicklerClass[T: c.WeakTypeTag](impl: PickleUnpickleImplementation): c.Tree = {
 
     val tpe = computeType[T]
-    val name = c.fresh(newTermName(syntheticBaseName(tpe) + "PicklerUnpickler"))
+    val name = c.freshName(TermName(syntheticBaseName(tpe) + "PicklerUnpickler"))
     val createTagTree = super[FastTypeTagMacros].impl[T]
     val unpickleLogic = genUnpicklerLogic[T](impl.unpickle)
     val pickleLogic = genPicklerLogic[T](impl.pickle)
@@ -446,7 +446,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
     */
   def registerUnPickledRef(instantiationLogic: c.Tree): c.Tree = {
     // TODO - We may not want to ALWAYS do this, some kind of enabling flag...
-    val instance = c.fresh(newTermName("instance"))
+    val instance = c.freshName(TermName("instance"))
     q"""
       val oid = _root_.scala.pickling.internal.`package`.currentRuntime.refRegistry.unpickle.preregisterUnpicklee()
       val $instance = $instantiationLogic
@@ -466,7 +466,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
 
   // -- Externalizable Hackery --
   def genExternalizablePickle(target: TermName, builder: TermName, pe: PickleExternalizable): c.Tree = {
-    val out = c.fresh(newTermName("out"))
+    val out = c.freshName(TermName("out"))
     val objectOutTpe = typeOf[scala.pickling.util.GenObjectOutput]
     val fieldName = "$ext"
     q"""val $out = new _root_.scala.pickling.util.GenObjectOutput
@@ -479,8 +479,8 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
 
   def genExternalizablUnPickle(reader: TermName, pe: UnpickleExternalizable): c.Tree = {
     val tpe = pe.tpe.tpe[c.universe.type](c.universe)
-    val readerName = c.fresh(newTermName("readerName"))
-    val target = c.fresh(newTermName("out"))
+    val readerName = c.freshName(TermName("readerName"))
+    val target = c.freshName(TermName("out"))
     val objectOutTpe = typeOf[scala.pickling.util.GenObjectOutput]
     val fieldName = "$ext"
     q"""
@@ -506,7 +506,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
     val valueTree =
       value match {
         case field: IrField =>
-          val fieldTerm = c.fresh(newTermName("field"))
+          val fieldTerm = c.freshName(TermName("field"))
           val get = q"""
                 val $fieldTerm = _root_.scala.pickling.internal.Reflect.getField($target.getClass, ${field.javaReflectionName})
                 $fieldTerm.setAccessible(true)
@@ -516,14 +516,14 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
         // Private scala methods may not encode normally for case classes.  This is a hack which goes after the field.
         // TODO - We should update this to look for the accessor method which scala generally exposes for the deconstructor.
         case mthd: IrMethod if mthd.isScala && mthd.isPrivate =>
-          val methodTerm = c.fresh(newTermName("mthd"))
+          val methodTerm = c.freshName(TermName("mthd"))
           // TODO - We may need to do a specialied lookup for magic named methods.
           q"""val $methodTerm = _root_.scala.pickling.internal.Reflect.getMethod($target.getClass, ${mthd.javaReflectionName}, Array())
               $methodTerm.setAccessible(true)
               $methodTerm.invoke($target)
               """
         case mthd: IrMethod =>
-          val methodTerm = c.fresh(newTermName("mthd"))
+          val methodTerm = c.freshName(TermName("mthd"))
           q"""val $methodTerm = _root_.scala.pickling.internal.Reflect.getMethod($target.getClass, ${mthd.javaReflectionName}, Array())
               $methodTerm.setAccessible(true)
               $methodTerm.invoke($target)"""
@@ -537,7 +537,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
     //        looking them up all the time.
     setter match {
       case field: IrField =>
-        val fieldTerm = c.fresh(newTermName("field"))
+        val fieldTerm = c.freshName(TermName("field"))
         val result = q"""
                  val $fieldTerm = _root_.scala.pickling.internal.Reflect.getField($target.getClass, ${field.javaReflectionName})
                  $fieldTerm.setAccessible(true)
@@ -545,7 +545,7 @@ private[pickling] trait SourceGenerator extends Macro with tags.FastTypeTagMacro
         // Workaround for issues with not being able to accurate read scala symbols.
         if(field.isScala) allowNonExistentField(result) else result
       case mthd: IrMethod =>
-        val methodTerm = c.fresh(newTermName("mthd"))
+        val methodTerm = c.freshName(TermName("mthd"))
         // TODO - We should ensure types align.
         val List(List(tpe)) = mthd.parameterTypes[c.universe.type](c.universe)
         q"""

--- a/core/src/main/scala/scala/pickling/runtime/Runtime.scala
+++ b/core/src/main/scala/scala/pickling/runtime/Runtime.scala
@@ -28,6 +28,8 @@ abstract class PicklerRuntime(classLoader: ClassLoader, preclazz: Class[_], shar
   import definitions._
   import scala.reflect.runtime.{universe => ru}
   import compat._
+  import ru.internal.existentialAbstraction
+
 
   val clazz = if (preclazz != null) Runtime.toUnboxed.getOrElse(preclazz, preclazz) else null
   val mirror = runtimeMirror(classLoader)
@@ -233,7 +235,7 @@ class InterpretedUnpicklerRuntime(val mirror: Mirror, typeTag: String)(implicit 
 
           // TODO: need to support modules and other special guys here
           // TODO: in principle, we could invoke a constructor here
-          val inst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz)
+          val inst = Tools.unsafe.allocateInstance(clazz)
           if (shouldBotherAboutSharing(tpe)) registerUnpicklee(inst, preregisterUnpicklee())
           val im = mirror.reflect(inst)
 
@@ -332,7 +334,7 @@ class ShareNothingInterpretedUnpicklerRuntime(val mirror: Mirror, typeTag: Strin
 
           // TODO: need to support modules and other special guys here
           // TODO: in principle, we could invoke a constructor here
-          val inst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz)
+          val inst = Tools.unsafe.allocateInstance(clazz)
           val im = mirror.reflect(inst)
 
           //debug(s"pendingFields: ${pendingFields.size}")

--- a/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
+++ b/core/src/main/scala/scala/pickling/runtime/RuntimePickler.scala
@@ -176,7 +176,7 @@ class RuntimePickler(classLoader: ClassLoader, clazz: Class[_], fastTag: FastTyp
         if (fir.accessor.nonEmpty)
           List(
             if (fir.tpe.typeSymbol.isEffectivelyFinal) new EffectivelyFinalLogic(fir)
-            else if (fir.tpe.typeSymbol.asType.isAbstractType) new AbstractLogic(fir)
+            else if (fir.tpe.typeSymbol.asType.isAbstract) new AbstractLogic(fir)
             else new DefaultLogic(fir)
           )
         else

--- a/core/src/main/scala/scala/pickling/tags/Compat.scala
+++ b/core/src/main/scala/scala/pickling/tags/Compat.scala
@@ -2,7 +2,7 @@ package scala.pickling
 package tags
 
 import scala.language.experimental.macros
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 // this is only necessary because 2.10.x doesn't support macro bundles
 object Compat {

--- a/core/src/main/scala/scala/pickling/tags/FastTypeTagMacros.scala
+++ b/core/src/main/scala/scala/pickling/tags/FastTypeTagMacros.scala
@@ -1,7 +1,7 @@
-package scala.pickling
-package tags
+package scala.pickling.tags
 
 import scala.language.experimental.macros
+import scala.pickling.Macro
 
 /** Macros which take compiler types and turn them into
  *  runtime string we can use to tag ADTs.
@@ -48,7 +48,6 @@ trait FastTypeTagMacros extends Macro {
   // TODO(joshuasuereth): This is may duplicate functionality with the `.tag` extension method on `Type`.
   def impl[T: c.WeakTypeTag]: c.Tree = {
     import c.universe._
-    import compat._
     val T = weakTypeOf[T]
     if (T.typeSymbol.isParameter)
       c.abort(c.enclosingPosition, s"cannot generate FastTypeTag for type parameter $T, FastTypeTag can only be generated for concrete types")

--- a/macro-test/src/main/scala/scala/pickling/generator/scalasymbols/Compat.scala
+++ b/macro-test/src/main/scala/scala/pickling/generator/scalasymbols/Compat.scala
@@ -2,7 +2,7 @@ package scala.pickling.generator.scalasymbols
 
 import scala.pickling.Macro
 import scala.pickling.generator.{IrSymbol, IrScalaSymbols}
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.reflect.runtime.{universe => ru}
 import scala.language.experimental.macros
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,9 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.0-M15"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
   lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.11.6"
-  lazy val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2"
+  lazy val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
   lazy val macroParadise = "org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full
   lazy val quasiquotes = "org.scalamacros" %% "quasiquotes" % "2.0.1"
   lazy val kryoSerializers = "de.javakaffee" % "kryo-serializers" % "0.22"

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -2,8 +2,6 @@ import sbt._
 import Keys._
 
 object Util {
-//  val buildScalaVersion = System.getProperty("scala.version", "2.11.8")
-//  val buildScalaVersions = Seq("2.11.8", "2.10.6")
   val buildScalaVersion = System.getProperty("scala.version", "2.12.1")
   val buildScalaVersions = Seq("2.12.1", "2.11.8")
   val javaVersion       = System.getProperty("java.version")

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -2,8 +2,10 @@ import sbt._
 import Keys._
 
 object Util {
-  val buildScalaVersion = System.getProperty("scala.version", "2.11.8")
-  val buildScalaVersions = Seq("2.11.8", "2.10.6")
+//  val buildScalaVersion = System.getProperty("scala.version", "2.11.8")
+//  val buildScalaVersions = Seq("2.11.8", "2.10.6")
+  val buildScalaVersion = System.getProperty("scala.version", "2.12.1")
+  val buildScalaVersions = Seq("2.12.1", "2.11.8")
   val javaVersion       = System.getProperty("java.version")
 
   def loadCredentials(): List[Credentials] = {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
- removed all the straight deprecations
- added access to sun.misc.Unsafe in Util - removed in 2.12
- might be useful if anyone wants to update the library for 2.12
- there are many other macro code deprecations that would take time to remove

Compiles except for benchmark and tests. If the build (`project/Util.scala`) is changed to 2.11.8 only, everything compiles and the tests run so clearly there are some differences when using 2.12.1 that don't work. I suspect that there is still a reference to `scala.concurrent.util.Unsafe.instance`. This would work in 2.11 but not 2.12.

Note: I used whitebox macros.